### PR TITLE
add encoder to TypedString and encoders package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+### Added
+
+- `WithEncoder()` string builder option.
+
 ## [1.0.3] - 2023-04-20
 
 ### Changed

--- a/builder_string.go
+++ b/builder_string.go
@@ -1,6 +1,7 @@
 package ferrite
 
 import (
+	"github.com/dogmatiq/ferrite/internal/encoders"
 	"github.com/dogmatiq/ferrite/variable"
 )
 
@@ -60,6 +61,12 @@ func (b *StringBuilder[T]) WithConstraint(
 // generated documentation.
 func (b *StringBuilder[T]) WithSensitiveContent() *StringBuilder[T] {
 	b.builder.MarkSensitive()
+	return b
+}
+
+// WithEncoder sets the encoder for parsing the value source.
+func (b *StringBuilder[T]) WithEncoder(encoder encoders.Encoder) *StringBuilder[T] {
+	b.schema.Encoder = encoder
 	return b
 }
 

--- a/builder_string_test.go
+++ b/builder_string_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/dogmatiq/ferrite"
 	. "github.com/dogmatiq/ferrite"
+	"github.com/dogmatiq/ferrite/internal/encoders"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -46,6 +47,35 @@ var _ = Describe("type StringBuilder", func() {
 						Value()
 
 					Expect(v).To(Equal(userDefinedString("<value>")))
+				})
+			})
+		})
+
+		When("the value is encoded", func() {
+			Describe("encoding.Hex", func() {
+				It("decodes a hex string", func() {
+					os.Setenv("FERRITE_STRING", "484558")
+					// "484558" == "HEX"
+
+					v := builder.
+						WithEncoder(encoders.Hex).
+						Required().
+						Value()
+
+					Expect(v).To(Equal(userDefinedString("HEX")))
+				})
+			})
+			Describe("encoding.Base64", func() {
+				It("decodes a hex string", func() {
+					os.Setenv("FERRITE_STRING", "SEVY")
+					// "SEVY" == "HEX"
+
+					v := builder.
+						WithEncoder(encoders.Base64).
+						Required().
+						Value()
+
+					Expect(v).To(Equal(userDefinedString("HEX")))
 				})
 			})
 		})

--- a/init.go
+++ b/init.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/dogmatiq/ferrite/internal/encoders"
 	"github.com/dogmatiq/ferrite/internal/mode"
 	"github.com/dogmatiq/ferrite/internal/mode/export/dotenv"
 	"github.com/dogmatiq/ferrite/internal/mode/usage/markdown"
@@ -31,6 +32,7 @@ import (
 func Init(options ...InitOption) {
 	cfg := initConfig{
 		mode.DefaultConfig,
+		encoders.None,
 	}
 
 	for _, opt := range options {
@@ -59,4 +61,5 @@ type InitOption interface {
 // InitOption values.
 type initConfig struct {
 	ModeConfig mode.Config
+	Encoder    encoders.Encoder
 }

--- a/internal/encoders/doc.go
+++ b/internal/encoders/doc.go
@@ -1,0 +1,1 @@
+package encoders

--- a/internal/encoders/encoders.go
+++ b/internal/encoders/encoders.go
@@ -1,0 +1,9 @@
+package encoders
+
+type Encoder string
+
+const (
+	None   Encoder = ""
+	Hex    Encoder = "hex"
+	Base64 Encoder = "base64"
+)


### PR DESCRIPTION
#### What change does this introduce?

Add `WithEncoder()` method to String type and encoders constants for `Hex` and `Base64`.

#### Why make this change?

Precursor to adding Bytes type

#### Is there anything you are unsure about?

Not sure if this fits where it is, I'm expecting some feedback on the implementation.

#### What issues does this relate to?

- #22 