### PR TITLE
io/ioutil is deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+### Changed
+
+- `io/ioutil.ReadFile` replaced with `os.ReadFile` in file builder
+
 ## [1.0.3] - 2023-04-20
 
 ### Changed

--- a/builder_file.go
+++ b/builder_file.go
@@ -2,7 +2,6 @@ package ferrite
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/dogmatiq/ferrite/variable"
@@ -65,7 +64,7 @@ func (n FileName) Reader() (io.ReadCloser, error) {
 
 // ReadBytes returns the contents of the file as a byte slice.
 func (n FileName) ReadBytes() ([]byte, error) {
-	return ioutil.ReadFile(string(n))
+	return os.ReadFile(string(n))
 }
 
 // ReadString returns the contents of the file as a string.


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

replace `io/ioutil.ReadFile` with `os.ReadFile`.

#### Why make this change?

`io/ioutil.ReadFile` is deprecated

#### Is there anything you are unsure about?

If there was a reason to stick with this other than just didn't notice it.

#### What issues does this relate to?

#66 
