### PR TITLE
Add binary variable types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,6 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ## [Unreleased]
 
-All backwards-incompatible changes in this version are within the `variable`
-sub-package, which remains experimental and outside the scope of the Ferrite
-project's stability guarantees.
-
 ### Added
 
 - Added `Binary()` and `BinaryAs()` builders for binary variables
@@ -23,8 +19,8 @@ project's stability guarantees.
 
 ### Changed
 
-- **[BC]** Replace `String` schema field of `variable.MinLengthError` and `MaxLengthError` with a `LengthLimited` schema
-- **[BC]** `variable.String` now implements the new `LengthLimited` interface
+- `variable.String` now implements the new `LengthLimited` interface
+- Rename the `variable.[Min|Max]LengthError.String` to `ViolatedSchema` and change its type to `LengthLimited`
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ## [Unreleased]
 
+All backwards-incompatible changes in this version are within the `variable`
+sub-package, which remains experimental and outside the scope of the Ferrite
+project's stability guarantees.
+
+### Added
+
+- Added `variable.LengthLimited` schema for values that have minimum or maximum lengths
+
+### Changed
+
+- **[BC]** Replace `String` schema field of `variable.MinLengthError` and `MaxLengthError` with a `LengthLimited` schema
+- **[BC]** `variable.String` now implements the new `LengthLimited` interface
+
 ### Removed
 
 - Removed "platform" examples from generated documentation. These are too

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ project's stability guarantees.
 
 ### Added
 
+- Added `Binary()` and `BinaryAs()` builders for binary variables
 - Added `variable.LengthLimited` schema for values that have minimum or maximum lengths
 
 ### Changed

--- a/builder_binary.go
+++ b/builder_binary.go
@@ -57,6 +57,18 @@ func (b *BinaryBuilder[T, B]) WithDefault(v T) *BinaryBuilder[T, B] {
 	return b
 }
 
+// WithDefaultString sets a default value of the variable to a string value.
+//
+// It is used when the environment variable is undefined or empty.
+func (b *BinaryBuilder[T, B]) WithDefaultString(v string) *BinaryBuilder[T, B] {
+	data := make(T, len(v))
+	for i := 0; i < len(v); i++ {
+		data[i] = B(v[i])
+	}
+	b.builder.Default(data)
+	return b
+}
+
 // WithConstraint adds a constraint to the variable.
 //
 // fn is called with the environment variable value after it is parsed. If fn

--- a/builder_binary.go
+++ b/builder_binary.go
@@ -1,0 +1,190 @@
+package ferrite
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+
+	"github.com/dogmatiq/ferrite/variable"
+)
+
+// Binary configures an environment variable as a raw binary value, represented
+// as a byte-slice.
+//
+// Binary values are represented in environment variables using a suitable
+// encoding schema. The default encoding is the standard "base64" encoding
+// described by RFC 4648.
+//
+// name is the name of the environment variable to read. desc is a
+// human-readable description of the environment variable.
+func Binary(name, desc string) *BinaryBuilder[[]byte, byte] {
+	return BinaryAs[[]byte](name, desc)
+}
+
+// BinaryAs configures an environment variable as a raw binary value,
+// represented as a user-defined byte-slice type.
+//
+// Binary values are represented in environment variables using a suitable
+// encoding schema. The default encoding is the standard "base64" encoding
+// described by RFC 4648.
+//
+// name is the name of the environment variable to read. desc is a
+// human-readable description of the environment variable.
+func BinaryAs[T ~[]B, B ~byte](name, desc string) *BinaryBuilder[T, B] {
+	b := &BinaryBuilder[T, B]{
+		schema: variable.TypedBinary[T, B]{},
+	}
+
+	b.builder.Name(name)
+	b.builder.Description(desc)
+	b.WithBase64Encoding(base64.StdEncoding)
+
+	return b
+}
+
+// BinaryBuilder builds a specification for a binary variable.
+type BinaryBuilder[T ~[]B, B ~byte] struct {
+	schema  variable.TypedBinary[T, B]
+	builder variable.TypedSpecBuilder[T]
+}
+
+var _ isBuilderOf[[]byte, *BinaryBuilder[[]byte, byte]]
+
+// WithDefault sets a default value of the variable.
+//
+// It is used when the environment variable is undefined or empty.
+func (b *BinaryBuilder[T, B]) WithDefault(v T) *BinaryBuilder[T, B] {
+	b.builder.Default(v)
+	return b
+}
+
+// WithConstraint adds a constraint to the variable.
+//
+// fn is called with the environment variable value after it is parsed. If fn
+// returns false the value is considered invalid.
+func (b *BinaryBuilder[T, B]) WithConstraint(
+	desc string,
+	fn func(T) bool,
+) *BinaryBuilder[T, B] {
+	b.builder.UserConstraint(desc, fn)
+	return b
+}
+
+// WithSensitiveContent marks the variable as containing sensitive content.
+//
+// Values of sensitive variables are not printed to the console or included in
+// generated documentation.
+func (b *BinaryBuilder[T, B]) WithSensitiveContent() *BinaryBuilder[T, B] {
+	b.builder.MarkSensitive()
+	return b
+}
+
+// WithBase64Encoding configures the variable to use base64 encoding to
+// represent the binary value within the environment.
+func (b *BinaryBuilder[T, B]) WithBase64Encoding(enc *base64.Encoding) *BinaryBuilder[T, B] {
+	b.schema.Marshaler = base64BinaryMarshaler[T, B]{Encoding: enc}
+	return b
+}
+
+// WithHexEncoding configures the variable to use hexadecimal encoding to
+// represent the binary value within the environment.
+func (b *BinaryBuilder[T, B]) WithHexEncoding() *BinaryBuilder[T, B] {
+	b.schema.Marshaler = hexBinaryMarshaler[T, B]{}
+	return b
+}
+
+// Required completes the build process and registers a required variable with
+// Ferrite's validation system.
+func (b *BinaryBuilder[T, B]) Required(options ...RequiredOption) Required[T] {
+	return required(b.schema, &b.builder, options...)
+}
+
+// Optional completes the build process and registers an optional variable with
+// Ferrite's validation system.
+func (b *BinaryBuilder[T, B]) Optional(options ...OptionalOption) Optional[T] {
+	return optional(b.schema, &b.builder, options...)
+}
+
+// Deprecated completes the build process and registers a deprecated variable
+// with Ferrite's validation system.
+func (b *BinaryBuilder[T, B]) Deprecated(options ...DeprecatedOption) Deprecated[T] {
+	return deprecated(b.schema, &b.builder, options...)
+}
+
+type base64BinaryMarshaler[T ~[]B, B ~byte] struct {
+	Encoding *base64.Encoding
+}
+
+func (m base64BinaryMarshaler[T, B]) Marshal(v T) (variable.Literal, error) {
+	return variable.Literal{
+		String: m.Encoding.EncodeToString(toByteSlice(v)),
+	}, nil
+}
+
+func (m base64BinaryMarshaler[T, B]) Unmarshal(v variable.Literal) (T, error) {
+	data, err := m.Encoding.DecodeString(v.String)
+	return fromByteSlice[T](data), err
+}
+
+func (m base64BinaryMarshaler[T, B]) EncodingDescription() string {
+	switch *m.Encoding {
+	case *base64.StdEncoding:
+		return "base64"
+	case *base64.RawStdEncoding:
+		return "base64-nopad"
+	case *base64.URLEncoding:
+		return "base64url"
+	case *base64.RawURLEncoding:
+		return "base64url-nopad"
+	default:
+		name := "base64-noncanonical"
+		if m.Encoding.EncodedLen(1) != base64.StdEncoding.EncodedLen(1) {
+			name += "-nopad"
+		}
+		return name
+	}
+}
+
+func (m base64BinaryMarshaler[T, B]) EncodedLen(n int) (min, max int) {
+	n = m.Encoding.EncodedLen(n)
+	return n, n
+}
+
+type hexBinaryMarshaler[T ~[]B, B ~byte] struct{}
+
+func (m hexBinaryMarshaler[T, B]) EncodingDescription() string {
+	return "hex"
+}
+
+func (m hexBinaryMarshaler[T, B]) Marshal(v T) (variable.Literal, error) {
+	return variable.Literal{
+		String: hex.EncodeToString(toByteSlice(v)),
+	}, nil
+}
+
+func (m hexBinaryMarshaler[T, B]) Unmarshal(v variable.Literal) (T, error) {
+	data, err := hex.DecodeString(v.String)
+	return fromByteSlice[T](data), err
+}
+
+func (m hexBinaryMarshaler[T, B]) EncodedLen(n int) (min, max int) {
+	n = hex.EncodedLen(n)
+	return n, n
+}
+
+// toByteSlice converts a slice of user-defined-byte type to []byte.
+func toByteSlice[T ~[]B, B ~byte](in T) []byte {
+	out := make([]byte, len(in))
+	for i, o := range in {
+		out[i] = byte(o)
+	}
+	return out
+}
+
+// fromByteSlice converts a []byte to a slice of user-defined-byte types.
+func fromByteSlice[T ~[]B, B ~byte](in []byte) T {
+	out := make(T, len(in))
+	for i, o := range in {
+		out[i] = B(o)
+	}
+	return out
+}

--- a/builder_binary_test.go
+++ b/builder_binary_test.go
@@ -160,6 +160,22 @@ func ExampleBinary_default() {
 	// value is <default>
 }
 
+func ExampleBinary_encodedDefault() {
+	defer example()()
+
+	v := ferrite.
+		Binary("FERRITE_BINARY", "example binary variable").
+		WithEncodedDefault("PGRlZmF1bHQ+").
+		Required()
+
+	ferrite.Init()
+
+	fmt.Println("value is", string(v.Value()))
+
+	// Output:
+	// value is <default>
+}
+
 func ExampleBinary_optional() {
 	defer example()()
 

--- a/builder_binary_test.go
+++ b/builder_binary_test.go
@@ -307,12 +307,12 @@ func ExampleBinary_encoding() {
 	custom := base64.NewEncoding("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz)!@#$%^&*(-_")
 
 	ferrite.
-		Binary("FERRITE_BINARY_BASE64_NONSTD", "base64 encoding, custom alphabet").
+		Binary("FERRITE_BINARY_BASE64_CUSTOM", "base64 encoding, custom alphabet").
 		WithBase64Encoding(custom).
 		Required()
 
 	ferrite.
-		Binary("FERRITE_BINARY_BASE64_NONSTD_RAW", "base64 encoding, custom alphabet, no padding").
+		Binary("FERRITE_BINARY_BASE64_CUSTOM_RAW", "base64 encoding, custom alphabet, no padding").
 		WithBase64Encoding(custom.WithPadding(base64.NoPadding)).
 		Required()
 
@@ -327,8 +327,8 @@ func ExampleBinary_encoding() {
 	// Environment Variables:
 	//
 	//  ❯ FERRITE_BINARY_BASE64             base64 encoding                                 <base64>                  ✗ undefined
-	//  ❯ FERRITE_BINARY_BASE64_NONSTD      base64 encoding, custom alphabet                <non-canonical base64>    ✗ undefined
-	//  ❯ FERRITE_BINARY_BASE64_NONSTD_RAW  base64 encoding, custom alphabet, no padding    <non-canonical base64>    ✗ undefined
+	//  ❯ FERRITE_BINARY_BASE64_CUSTOM      base64 encoding, custom alphabet                <non-canonical base64>    ✗ undefined
+	//  ❯ FERRITE_BINARY_BASE64_CUSTOM_RAW  base64 encoding, custom alphabet, no padding    <non-canonical base64>    ✗ undefined
 	//  ❯ FERRITE_BINARY_BASE64_RAW         base64 encoding, no padding                     <unpadded base64>         ✗ undefined
 	//  ❯ FERRITE_BINARY_BASE64_URL         base64 encoding, url safe                       <padded base64url>        ✗ undefined
 	//  ❯ FERRITE_BINARY_BASE64_URL_RAW     base64 encoding, url safe, no padding           <base64url>               ✗ undefined

--- a/builder_binary_test.go
+++ b/builder_binary_test.go
@@ -202,7 +202,7 @@ func ExampleBinary_sensitive() {
 	// Output:
 	// Environment Variables:
 	//
-	//  ❯ FERRITE_BINARY  example sensitive binary variable    <base64>    ✗ set to 12-byte value, always fail
+	//  ❯ FERRITE_BINARY  example sensitive binary variable    <base64>    ✗ set to {12 bytes}, always fail
 	//
 	// <process exited with error code 1>
 }
@@ -226,7 +226,7 @@ func ExampleBinary_deprecated() {
 	// Output:
 	// Environment Variables:
 	//
-	//  ❯ FERRITE_BINARY  example binary variable  [ <base64> ]  ⚠ deprecated variable set to 12-byte value
+	//  ❯ FERRITE_BINARY  example binary variable  [ <base64> ]  ⚠ deprecated variable set to {12 bytes}
 	//
 	// value is <value>
 }

--- a/builder_binary_test.go
+++ b/builder_binary_test.go
@@ -281,3 +281,58 @@ func ExampleBinary_deprecated() {
 	//
 	// value is <value>
 }
+
+func ExampleBinary_encoding() {
+	defer example()()
+
+	ferrite.
+		Binary("FERRITE_BINARY_BASE64", "base64 encoding").
+		Required()
+
+	ferrite.
+		Binary("FERRITE_BINARY_BASE64_RAW", "base64 encoding, no padding").
+		WithBase64Encoding(base64.RawStdEncoding).
+		Required()
+
+	ferrite.
+		Binary("FERRITE_BINARY_BASE64_URL", "base64 encoding, url safe").
+		WithBase64Encoding(base64.URLEncoding).
+		Required()
+
+	ferrite.
+		Binary("FERRITE_BINARY_BASE64_URL_RAW", "base64 encoding, url safe, no padding").
+		WithBase64Encoding(base64.RawURLEncoding).
+		Required()
+
+	custom := base64.NewEncoding("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz)!@#$%^&*(-_")
+
+	ferrite.
+		Binary("FERRITE_BINARY_BASE64_NONSTD", "base64 encoding, custom alphabet").
+		WithBase64Encoding(custom).
+		Required()
+
+	ferrite.
+		Binary("FERRITE_BINARY_BASE64_NONSTD_RAW", "base64 encoding, custom alphabet, no padding").
+		WithBase64Encoding(custom.WithPadding(base64.NoPadding)).
+		Required()
+
+	ferrite.
+		Binary("FERRITE_BINARY_HEX", "hexadecimal encoding").
+		WithHexEncoding().
+		Required()
+
+	ferrite.Init()
+
+	// Output:
+	// Environment Variables:
+	//
+	//  ❯ FERRITE_BINARY_BASE64             base64 encoding                                 <base64>                  ✗ undefined
+	//  ❯ FERRITE_BINARY_BASE64_NONSTD      base64 encoding, custom alphabet                <non-canonical base64>    ✗ undefined
+	//  ❯ FERRITE_BINARY_BASE64_NONSTD_RAW  base64 encoding, custom alphabet, no padding    <non-canonical base64>    ✗ undefined
+	//  ❯ FERRITE_BINARY_BASE64_RAW         base64 encoding, no padding                     <unpadded base64>         ✗ undefined
+	//  ❯ FERRITE_BINARY_BASE64_URL         base64 encoding, url safe                       <padded base64url>        ✗ undefined
+	//  ❯ FERRITE_BINARY_BASE64_URL_RAW     base64 encoding, url safe, no padding           <base64url>               ✗ undefined
+	//  ❯ FERRITE_BINARY_HEX                hexadecimal encoding                            <hex>                     ✗ undefined
+	//
+	// <process exited with error code 1>
+}

--- a/builder_binary_test.go
+++ b/builder_binary_test.go
@@ -1,6 +1,7 @@
 package ferrite_test
 
 import (
+	"encoding/base64"
 	"fmt"
 	"os"
 
@@ -205,6 +206,40 @@ func ExampleBinary_sensitive() {
 	//  ❯ FERRITE_BINARY  example sensitive binary variable    <base64>    ✗ set to {12 bytes}, always fail
 	//
 	// <process exited with error code 1>
+}
+
+func ExampleBinary_base64url() {
+	defer example()()
+
+	v := ferrite.
+		Binary("FERRITE_BINARY", "example binary variable").
+		WithBase64Encoding(base64.RawURLEncoding).
+		Required()
+
+	os.Setenv("FERRITE_BINARY", "_w") // would be "/w==" with standard base64 encoding
+	ferrite.Init()
+
+	fmt.Println("value is", v.Value())
+
+	// Output:
+	// value is [255]
+}
+
+func ExampleBinary_hex() {
+	defer example()()
+
+	v := ferrite.
+		Binary("FERRITE_BINARY", "example binary variable").
+		WithHexEncoding().
+		Required()
+
+	os.Setenv("FERRITE_BINARY", "3c76616c75653e")
+	ferrite.Init()
+
+	fmt.Println("value is", string(v.Value()))
+
+	// Output:
+	// value is <value>
 }
 
 func ExampleBinary_deprecated() {

--- a/builder_binary_test.go
+++ b/builder_binary_test.go
@@ -1,0 +1,232 @@
+package ferrite_test
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/dogmatiq/ferrite"
+	. "github.com/dogmatiq/ferrite"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type userDefinedByte byte
+type userDefinedBinary []userDefinedByte
+
+var _ = Describe("type BinaryBuilder", func() {
+	var builder *BinaryBuilder[userDefinedBinary, userDefinedByte]
+
+	BeforeEach(func() {
+		builder = BinaryAs[userDefinedBinary]("FERRITE_BINARY", "<desc>")
+	})
+
+	AfterEach(func() {
+		tearDown()
+	})
+
+	It("panics if the name is empty", func() {
+		Expect(func() {
+			BinaryAs[userDefinedBinary]("", "<desc>").Optional()
+		}).To(PanicWith("invalid specification: variable name must not be empty"))
+	})
+
+	It("panics if the description is empty", func() {
+		Expect(func() {
+			BinaryAs[userDefinedBinary]("FERRITE_BINARY", "").Optional()
+		}).To(PanicWith("specification for FERRITE_BINARY is invalid: variable description must not be empty"))
+	})
+
+	When("the variable is required", func() {
+		When("the value is not empty", func() {
+			Describe("func Value()", func() {
+				It("returns the value ", func() {
+					os.Setenv("FERRITE_BINARY", "PHZhbHVlPg==")
+
+					v := builder.
+						Required().
+						Value()
+
+					Expect(v).To(Equal(userDefinedBinary("<value>")))
+				})
+			})
+		})
+
+		When("the value is empty", func() {
+			When("there is a default value", func() {
+				Describe("func Value()", func() {
+					It("returns the default", func() {
+						v := builder.
+							WithDefault(userDefinedBinary("<value>")).
+							Required().
+							Value()
+
+						Expect(v).To(Equal(userDefinedBinary("<value>")))
+					})
+				})
+			})
+
+			When("there is no default value", func() {
+				Describe("func Value()", func() {
+					It("panics", func() {
+						Expect(func() {
+							builder.
+								Required().
+								Value()
+						}).To(PanicWith(
+							"FERRITE_BINARY is undefined and does not have a default value",
+						))
+					})
+				})
+			})
+		})
+	})
+
+	When("the variable is optional", func() {
+		When("the value is not empty", func() {
+			Describe("func Value()", func() {
+				It("returns the value ", func() {
+					os.Setenv("FERRITE_BINARY", "PHZhbHVlPg==")
+
+					v, ok := builder.
+						Optional().
+						Value()
+
+					Expect(ok).To(BeTrue())
+					Expect(v).To(Equal(userDefinedBinary("<value>")))
+				})
+			})
+		})
+
+		When("the value is empty", func() {
+			When("there is a default value", func() {
+				Describe("func Value()", func() {
+					It("returns the default", func() {
+						v, ok := builder.
+							WithDefault(userDefinedBinary("<value>")).
+							Optional().
+							Value()
+
+						Expect(ok).To(BeTrue())
+						Expect(v).To(Equal(userDefinedBinary("<value>")))
+					})
+				})
+			})
+
+			When("there is no default value", func() {
+				Describe("func Value()", func() {
+					It("returns with ok == false", func() {
+						_, ok := builder.
+							Optional().
+							Value()
+
+						Expect(ok).To(BeFalse())
+					})
+				})
+			})
+		})
+	})
+})
+
+func ExampleBinary_required() {
+	defer example()()
+
+	v := ferrite.
+		Binary("FERRITE_BINARY", "example binary variable").
+		Required()
+
+	os.Setenv("FERRITE_BINARY", "PHZhbHVlPg==")
+	ferrite.Init()
+
+	fmt.Println("value is", string(v.Value()))
+
+	// Output:
+	// value is <value>
+}
+
+func ExampleBinary_default() {
+	defer example()()
+
+	v := ferrite.
+		Binary("FERRITE_BINARY", "example binary variable").
+		WithDefault([]byte("<default>")).
+		Required()
+
+	ferrite.Init()
+
+	fmt.Println("value is", string(v.Value()))
+
+	// Output:
+	// value is <default>
+}
+
+func ExampleBinary_optional() {
+	defer example()()
+
+	v := ferrite.
+		Binary("FERRITE_BINARY", "example binary variable").
+		Optional()
+
+	ferrite.Init()
+
+	if x, ok := v.Value(); ok {
+		fmt.Println("value is", string(x))
+	} else {
+		fmt.Println("value is undefined")
+	}
+
+	// Output:
+	// value is undefined
+}
+
+func ExampleBinary_sensitive() {
+	defer example()()
+
+	os.Setenv("FERRITE_BINARY", "aHVudGVyMg==")
+	ferrite.
+		Binary("FERRITE_BINARY", "example sensitive binary variable").
+		WithConstraint(
+			"always fail",
+			func(v []byte) bool {
+				// Force the variable to be considered invalid so that the
+				// variable table is rendered to the console.
+				return false
+			},
+		).
+		WithSensitiveContent().
+		Required()
+
+	ferrite.Init()
+
+	// Note that the variable's value is obscured in the console output.
+
+	// Output:
+	// Environment Variables:
+	//
+	//  ❯ FERRITE_BINARY  example sensitive binary variable    <base64>    ✗ set to 12-byte value, always fail
+	//
+	// <process exited with error code 1>
+}
+
+func ExampleBinary_deprecated() {
+	defer example()()
+
+	os.Setenv("FERRITE_BINARY", "PHZhbHVlPg==")
+	v := ferrite.
+		Binary("FERRITE_BINARY", "example binary variable").
+		Deprecated()
+
+	ferrite.Init()
+
+	if x, ok := v.DeprecatedValue(); ok {
+		fmt.Println("value is", string(x))
+	} else {
+		fmt.Println("value is undefined")
+	}
+
+	// Output:
+	// Environment Variables:
+	//
+	//  ❯ FERRITE_BINARY  example binary variable  [ <base64> ]  ⚠ deprecated variable set to 12-byte value
+	//
+	// value is <value>
+}

--- a/builder_string_test.go
+++ b/builder_string_test.go
@@ -185,7 +185,7 @@ func ExampleString_sensitive() {
 		String("FERRITE_STRING", "example sensitive string variable").
 		WithConstraint(
 			"always fail",
-			func(s string) bool {
+			func(v string) bool {
 				// Force the variable to be considered invalid so that the
 				// variable table is rendered to the console.
 				return false

--- a/internal/limits/limits.go
+++ b/internal/limits/limits.go
@@ -43,7 +43,7 @@ func Of[T constraints.Integer | constraints.Float]() (min, max T) {
 		return limits[float32, T](-math.MaxFloat32, +math.MaxFloat32)
 
 	default:
-		panic("not implemented")
+		panic("type does not meet expected constraints")
 	}
 }
 

--- a/internal/mode/export/dotenv/run.go
+++ b/internal/mode/export/dotenv/run.go
@@ -1,9 +1,8 @@
 package dotenv
 
 import (
-	"strings"
-
 	"github.com/dogmatiq/ferrite/internal/mode"
+	"github.com/dogmatiq/ferrite/internal/mode/internal/render"
 	"github.com/dogmatiq/ferrite/variable"
 	"github.com/dogmatiq/iago/must"
 )
@@ -21,11 +20,8 @@ func Run(cfg mode.Config) {
 		must.Fprintf(cfg.Out, "# %s (", s.Description())
 
 		if def, ok := s.Default(); ok {
-			x := def.Quote()
-			if s.IsSensitive() {
-				x = strings.Repeat("*", len(x))
-			}
-			must.Fprintf(cfg.Out, "default: %s", x)
+			must.WriteString(cfg.Out, "default: ")
+			must.WriteString(cfg.Out, render.Value(s, def))
 		} else if s.IsDeprecated() {
 			must.Fprintf(cfg.Out, "deprecated")
 		} else if s.IsRequired() {

--- a/internal/mode/internal/render/doc.go
+++ b/internal/mode/internal/render/doc.go
@@ -1,0 +1,3 @@
+// Package render contains utilities for rendering variable values and schema
+// descriptions in a consistent way across various modes.
+package render

--- a/internal/mode/internal/render/value.go
+++ b/internal/mode/internal/render/value.go
@@ -1,0 +1,77 @@
+package render
+
+import (
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/dogmatiq/ferrite/variable"
+)
+
+// Value returns a value rendered for display within documentation and other
+// human-readable output.
+func Value(s variable.Spec, v variable.Literal) string {
+	vis := &valueRenderer{
+		Spec: s,
+		In:   v,
+		Out:  &strings.Builder{},
+	}
+
+	s.Schema().AcceptVisitor(vis)
+
+	return vis.Out.String()
+}
+
+// WriteValue renders a value for display within documentation and other
+// human-readable output.
+func WriteValue(w io.Writer, s variable.Spec, v variable.Literal) {
+
+}
+
+type valueRenderer struct {
+	Spec variable.Spec
+	In   variable.Literal
+	Out  *strings.Builder
+}
+
+func (r *valueRenderer) VisitBinary(s variable.Binary) {
+	n := len(r.In.String)
+
+	r.Out.WriteByte('{')
+	r.Out.WriteString(strconv.Itoa(n))
+	r.Out.WriteString(" byte")
+
+	if n != 1 {
+		r.Out.WriteByte('s')
+	}
+
+	r.Out.WriteByte('}')
+}
+
+func (r *valueRenderer) VisitNumeric(s variable.Numeric) {
+	r.visitGeneric(s)
+}
+
+func (r *valueRenderer) VisitSet(s variable.Set) {
+	r.visitGeneric(s)
+}
+
+func (r *valueRenderer) VisitString(s variable.String) {
+	r.visitGeneric(s)
+}
+
+func (r *valueRenderer) VisitOther(s variable.Other) {
+	r.visitGeneric(s)
+}
+
+func (r *valueRenderer) visitGeneric(s variable.Schema) {
+	if r.Spec.IsSensitive() {
+		n := len(r.In.String)
+		r.Out.Grow(n)
+		for i := 0; i < n; i++ {
+			r.Out.WriteByte('*')
+		}
+	} else {
+		r.Out.WriteString(r.In.Quote())
+	}
+}

--- a/internal/mode/usage/markdown/spec.go
+++ b/internal/mode/usage/markdown/spec.go
@@ -60,8 +60,8 @@ func (r *specRenderer) VisitNumeric(s variable.Numeric) {
 	}
 }
 
-// VisitSet renders the primary requirement for spec that uses the "set" schema
-// type.
+// VisitSet renders the primary requirement for a spec that uses the "set"
+// schema type.
 func (r *specRenderer) VisitSet(s variable.Set) {
 	if lits := s.Literals(); len(lits) == 2 {
 		r.renderPrimaryRequirement(

--- a/internal/mode/usage/markdown/spec.go
+++ b/internal/mode/usage/markdown/spec.go
@@ -36,8 +36,14 @@ func (r *specRenderer) Render() {
 	r.renderSeeAlso()
 }
 
-// VisitNumeric renders the primary requirement for spec that uses the "numeric"
-// schema type.
+// VisitBinary renders the primary requirement for a spec that uses the
+// "binary" schema type.
+func (r *specRenderer) VisitBinary(s variable.Binary) {
+	panic("not implemented")
+}
+
+// VisitNumeric renders the primary requirement for a spec that uses the
+// "numeric" schema type.
 func (r *specRenderer) VisitNumeric(s variable.Numeric) {
 	min, hasMin := s.Min()
 	max, hasMax := s.Max()

--- a/internal/mode/usage/markdown/spec.go
+++ b/internal/mode/usage/markdown/spec.go
@@ -39,7 +39,23 @@ func (r *specRenderer) Render() {
 // VisitBinary renders the primary requirement for a spec that uses the
 // "binary" schema type.
 func (r *specRenderer) VisitBinary(s variable.Binary) {
-	panic("not implemented")
+	// Find the best constraint to use as the "primary" requirement, favoring
+	// non-user-defined constraints.
+	var con variable.Constraint
+	for _, c := range r.spec.Constraints() {
+		if !c.IsUserDefined() {
+			con = c
+			break
+		} else if con == nil {
+			con = c
+		}
+	}
+
+	if con == nil {
+		r.renderPrimaryRequirement("**MUST** be a binary value expressed using the `%s` encoding scheme", s.EncodingDescription())
+	} else {
+		r.renderPrimaryRequirement(con.Description())
+	}
 }
 
 // VisitNumeric renders the primary requirement for a spec that uses the

--- a/internal/mode/usage/markdown/spec.go
+++ b/internal/mode/usage/markdown/spec.go
@@ -39,22 +39,10 @@ func (r *specRenderer) Render() {
 // VisitBinary renders the primary requirement for a spec that uses the
 // "binary" schema type.
 func (r *specRenderer) VisitBinary(s variable.Binary) {
-	// Find the best constraint to use as the "primary" requirement, favoring
-	// non-user-defined constraints.
-	var con variable.Constraint
-	for _, c := range r.spec.Constraints() {
-		if !c.IsUserDefined() {
-			con = c
-			break
-		} else if con == nil {
-			con = c
-		}
-	}
-
-	if con == nil {
-		r.renderPrimaryRequirement("**MUST** be a binary value expressed using the `%s` encoding scheme", s.EncodingDescription())
-	} else {
+	if con := r.bestConstraint(); con != nil {
 		r.renderPrimaryRequirement(con.Description())
+	} else {
+		r.renderPrimaryRequirement("**MUST** be a binary value expressed using the `%s` encoding scheme", s.EncodingDescription())
 	}
 }
 
@@ -99,22 +87,10 @@ func (r *specRenderer) VisitSet(s variable.Set) {
 // VisitString renders the primary requirement for a spec that uses the "string"
 // schema type.
 func (r *specRenderer) VisitString(variable.String) {
-	// Find the best constraint to use as the "primary" requirement, favoring
-	// non-user-defined constraints.
-	var con variable.Constraint
-	for _, c := range r.spec.Constraints() {
-		if !c.IsUserDefined() {
-			con = c
-			break
-		} else if con == nil {
-			con = c
-		}
-	}
-
-	if con == nil {
-		r.renderPrimaryRequirement("")
-	} else {
+	if con := r.bestConstraint(); con != nil {
 		r.renderPrimaryRequirement(con.Description())
+	} else {
+		r.renderPrimaryRequirement("")
 	}
 }
 
@@ -271,4 +247,22 @@ func (r *specRenderer) renderDependsOnClause() string {
 			)
 		},
 	)
+}
+
+// bestConstraint returns the constraint to use as the "primary"
+// requirement, favoring non-user-defined constraints.
+func (r *specRenderer) bestConstraint() (con variable.Constraint) {
+	constraints := r.spec.Constraints()
+
+	for _, c := range constraints {
+		if !c.IsUserDefined() {
+			return c
+		}
+	}
+
+	for _, c := range constraints {
+		return c
+	}
+
+	return nil
 }

--- a/internal/mode/usage/markdown/spec_binary_test.go
+++ b/internal/mode/usage/markdown/spec_binary_test.go
@@ -48,7 +48,7 @@ var _ = DescribeTable(
 		func(reg *variable.Registry) {
 			ferrite.
 				Binary("FAVICON", "the content of the favicon.png file").
-				WithDefaultString("<favicon content>").
+				WithDefault([]byte("<favicon content>")).
 				Optional(ferrite.WithRegistry(reg))
 		},
 	),
@@ -58,7 +58,7 @@ var _ = DescribeTable(
 		func(reg *variable.Registry) {
 			ferrite.
 				Binary("FAVICON", "the content of the favicon.png file").
-				WithDefaultString("<favicon content>").
+				WithDefault([]byte("<favicon content>")).
 				Required(ferrite.WithRegistry(reg))
 		},
 	),
@@ -92,7 +92,7 @@ var _ = DescribeTable(
 		func(reg *variable.Registry) {
 			ferrite.
 				Binary("SECRET_KEY", "a very secret machine-readable key").
-				WithDefaultString("hunter2").
+				WithDefault([]byte("hunter2")).
 				WithSensitiveContent().
 				Optional(
 					ferrite.WithRegistry(reg),
@@ -105,7 +105,7 @@ var _ = DescribeTable(
 		func(reg *variable.Registry) {
 			ferrite.
 				Binary("SECRET_KEY", "a very secret machine-readable key").
-				WithDefaultString("hunter2").
+				WithDefault([]byte("hunter2")).
 				WithSensitiveContent().
 				Required(
 					ferrite.WithRegistry(reg),

--- a/internal/mode/usage/markdown/spec_binary_test.go
+++ b/internal/mode/usage/markdown/spec_binary_test.go
@@ -1,0 +1,115 @@
+package markdown_test
+
+import (
+	"github.com/dogmatiq/ferrite"
+	. "github.com/dogmatiq/ferrite/internal/mode/usage/markdown"
+	"github.com/dogmatiq/ferrite/variable"
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = DescribeTable(
+	"binary spec",
+	tableTest(
+		"spec/binary",
+		WithoutExplanatoryText(),
+		WithoutIndex(),
+		WithoutUsageExamples(),
+	),
+	Entry(
+		"deprecated",
+		"deprecated.md",
+		func(reg *variable.Registry) {
+			ferrite.
+				Binary("FAVICON", "the content of the favicon.png file").
+				Deprecated(ferrite.WithRegistry(reg))
+		},
+	),
+	Entry(
+		"optional",
+		"optional.md",
+		func(reg *variable.Registry) {
+			ferrite.
+				Binary("FAVICON", "the content of the favicon.png file").
+				Optional(ferrite.WithRegistry(reg))
+		},
+	),
+	Entry(
+		"required",
+		"required.md",
+		func(reg *variable.Registry) {
+			ferrite.
+				Binary("FAVICON", "the content of the favicon.png file").
+				Required(ferrite.WithRegistry(reg))
+		},
+	),
+	Entry(
+		"optional with default value",
+		"with-default.md",
+		func(reg *variable.Registry) {
+			ferrite.
+				Binary("FAVICON", "the content of the favicon.png file").
+				WithDefaultString("<favicon content>").
+				Optional(ferrite.WithRegistry(reg))
+		},
+	),
+	Entry(
+		"required with default value",
+		"with-default.md",
+		func(reg *variable.Registry) {
+			ferrite.
+				Binary("FAVICON", "the content of the favicon.png file").
+				WithDefaultString("<favicon content>").
+				Required(ferrite.WithRegistry(reg))
+		},
+	),
+	Entry(
+		"optional with sensitive content",
+		"with-sensitive-optional.md",
+		func(reg *variable.Registry) {
+			ferrite.
+				Binary("SECRET_KEY", "a very secret machine-readable key").
+				WithSensitiveContent().
+				Optional(
+					ferrite.WithRegistry(reg),
+				)
+		},
+	),
+	Entry(
+		"required with sensitive content",
+		"with-sensitive-required.md",
+		func(reg *variable.Registry) {
+			ferrite.
+				Binary("SECRET_KEY", "a very secret machine-readable key").
+				WithSensitiveContent().
+				Required(
+					ferrite.WithRegistry(reg),
+				)
+		},
+	),
+	Entry(
+		"optional with sensitive content and default value",
+		"with-sensitive-with-default.md",
+		func(reg *variable.Registry) {
+			ferrite.
+				Binary("SECRET_KEY", "a very secret machine-readable key").
+				WithDefaultString("hunter2").
+				WithSensitiveContent().
+				Optional(
+					ferrite.WithRegistry(reg),
+				)
+		},
+	),
+	Entry(
+		"required with sensitive content and default value",
+		"with-sensitive-with-default.md",
+		func(reg *variable.Registry) {
+			ferrite.
+				Binary("SECRET_KEY", "a very secret machine-readable key").
+				WithDefaultString("hunter2").
+				WithSensitiveContent().
+				Required(
+					ferrite.WithRegistry(reg),
+				)
+		},
+	),
+)

--- a/internal/mode/usage/markdown/testdata/spec/binary/deprecated.md
+++ b/internal/mode/usage/markdown/testdata/spec/binary/deprecated.md
@@ -1,0 +1,15 @@
+# Environment Variables
+
+## Specification
+
+### `FAVICON`
+
+> the content of the favicon.png file
+
+⚠️ The `FAVICON` variable is **deprecated**; its use is **NOT RECOMMENDED** as
+it may be removed in a future version. If defined, the value **MUST** be a
+binary value expressed using the `base64` encoding scheme.
+
+```bash
+export FAVICON=pDBEuK+Y5AyfhrO1zlCqhQ== # (non-normative)
+```

--- a/internal/mode/usage/markdown/testdata/spec/binary/optional.md
+++ b/internal/mode/usage/markdown/testdata/spec/binary/optional.md
@@ -1,0 +1,14 @@
+# Environment Variables
+
+## Specification
+
+### `FAVICON`
+
+> the content of the favicon.png file
+
+The `FAVICON` variable **MAY** be left undefined. Otherwise, the value **MUST**
+be a binary value expressed using the `base64` encoding scheme.
+
+```bash
+export FAVICON=pDBEuK+Y5AyfhrO1zlCqhQ== # (non-normative)
+```

--- a/internal/mode/usage/markdown/testdata/spec/binary/required.md
+++ b/internal/mode/usage/markdown/testdata/spec/binary/required.md
@@ -1,0 +1,14 @@
+# Environment Variables
+
+## Specification
+
+### `FAVICON`
+
+> the content of the favicon.png file
+
+The `FAVICON` variable's value **MUST** be a binary value expressed using the
+`base64` encoding scheme.
+
+```bash
+export FAVICON=pDBEuK+Y5AyfhrO1zlCqhQ== # (non-normative)
+```

--- a/internal/mode/usage/markdown/testdata/spec/binary/with-default.md
+++ b/internal/mode/usage/markdown/testdata/spec/binary/with-default.md
@@ -1,0 +1,15 @@
+# Environment Variables
+
+## Specification
+
+### `FAVICON`
+
+> the content of the favicon.png file
+
+The `FAVICON` variable **MAY** be left undefined, in which case the default
+value of `PGZhdmljb24gY29udGVudD4=` is used. Otherwise, the value **MUST** be a
+binary value expressed using the `base64` encoding scheme.
+
+```bash
+export FAVICON=PGZhdmljb24gY29udGVudD4= # (default)
+```

--- a/internal/mode/usage/markdown/testdata/spec/binary/with-sensitive-optional.md
+++ b/internal/mode/usage/markdown/testdata/spec/binary/with-sensitive-optional.md
@@ -1,0 +1,12 @@
+# Environment Variables
+
+## Specification
+
+### `SECRET_KEY`
+
+> a very secret machine-readable key
+
+The `SECRET_KEY` variable **MAY** be left undefined. Otherwise, the value
+**MUST** be a binary value expressed using the `base64` encoding scheme.
+
+⚠️ This variable is **sensitive**; its value may contain private information.

--- a/internal/mode/usage/markdown/testdata/spec/binary/with-sensitive-required.md
+++ b/internal/mode/usage/markdown/testdata/spec/binary/with-sensitive-required.md
@@ -1,0 +1,12 @@
+# Environment Variables
+
+## Specification
+
+### `SECRET_KEY`
+
+> a very secret machine-readable key
+
+The `SECRET_KEY` variable's value **MUST** be a binary value expressed using the
+`base64` encoding scheme.
+
+⚠️ This variable is **sensitive**; its value may contain private information.

--- a/internal/mode/usage/markdown/testdata/spec/binary/with-sensitive-with-default.md
+++ b/internal/mode/usage/markdown/testdata/spec/binary/with-sensitive-with-default.md
@@ -1,0 +1,13 @@
+# Environment Variables
+
+## Specification
+
+### `SECRET_KEY`
+
+> a very secret machine-readable key
+
+The `SECRET_KEY` variable **MAY** be left undefined, in which case a default
+value is used. Otherwise, the value **MUST** be a binary value expressed using
+the `base64` encoding scheme.
+
+⚠️ This variable is **sensitive**; its value may contain private information.

--- a/internal/mode/validate/column_spec.go
+++ b/internal/mode/validate/column_spec.go
@@ -36,14 +36,10 @@ type schemaRenderer struct {
 	Output *strings.Builder
 }
 
-func (r *schemaRenderer) VisitSet(s variable.Set) {
-	for i, m := range s.Literals() {
-		if i > 0 {
-			r.Output.WriteString(" | ")
-		}
-
-		r.Output.WriteString(m.Quote())
-	}
+func (r *schemaRenderer) VisitBinary(s variable.Binary) {
+	r.Output.WriteByte('<')
+	r.Output.WriteString(s.EncodingDescription())
+	r.Output.WriteByte('>')
 }
 
 func (r *schemaRenderer) VisitNumeric(s variable.Numeric) {
@@ -75,6 +71,16 @@ func (r *schemaRenderer) VisitNumeric(s variable.Numeric) {
 			"<%s>",
 			s.Type().Kind(),
 		)
+	}
+}
+
+func (r *schemaRenderer) VisitSet(s variable.Set) {
+	for i, m := range s.Literals() {
+		if i > 0 {
+			r.Output.WriteString(" | ")
+		}
+
+		r.Output.WriteString(m.Quote())
 	}
 }
 

--- a/internal/mode/validate/column_spec.go
+++ b/internal/mode/validate/column_spec.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/dogmatiq/ferrite/internal/mode/internal/render"
 	"github.com/dogmatiq/ferrite/variable"
 )
 
@@ -21,7 +22,7 @@ func spec(v variable.Any) string {
 		return fmt.Sprintf(
 			"[ %s ] = %s",
 			out,
-			renderValue(s, def),
+			render.Value(s, def),
 		)
 	}
 

--- a/internal/mode/validate/column_value.go
+++ b/internal/mode/validate/column_value.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/dogmatiq/ferrite/internal/mode/internal/render"
 	"github.com/dogmatiq/ferrite/variable"
 )
 
@@ -22,7 +23,7 @@ func value(v variable.Any) string {
 		}
 
 		out.WriteString("set to ")
-		out.WriteString(renderValue(s, lit))
+		out.WriteString(render.Value(s, lit))
 
 		if message != "" {
 			out.WriteString(", ")
@@ -62,54 +63,10 @@ func value(v variable.Any) string {
 		if value.Verbatim() != value.Canonical() {
 			message = fmt.Sprintf(
 				"equivalent to %s",
-				renderValue(s, value.Canonical()),
+				render.Value(s, value.Canonical()),
 			)
 		}
 
 		return renderExplicit(icon, value.Verbatim(), message)
-	}
-}
-
-func renderValue(s variable.Spec, v variable.Literal) string {
-	vis := &valueRenderer{
-		Spec: s,
-		In:   v,
-	}
-	s.Schema().AcceptVisitor(vis)
-
-	return vis.Out
-}
-
-type valueRenderer struct {
-	Spec variable.Spec
-	In   variable.Literal
-	Out  string
-}
-
-func (r *valueRenderer) VisitBinary(s variable.Binary) {
-	r.Out = fmt.Sprintf("%d-byte value", len(r.In.String))
-}
-
-func (r *valueRenderer) VisitNumeric(s variable.Numeric) {
-	r.visitGeneric(s)
-}
-
-func (r *valueRenderer) VisitSet(s variable.Set) {
-	r.visitGeneric(s)
-}
-
-func (r *valueRenderer) VisitString(s variable.String) {
-	r.visitGeneric(s)
-}
-
-func (r *valueRenderer) VisitOther(s variable.Other) {
-	r.visitGeneric(s)
-}
-
-func (r *valueRenderer) visitGeneric(s variable.Schema) {
-	if r.Spec.IsSensitive() {
-		r.Out = strings.Repeat("*", len(r.In.String))
-	} else {
-		r.Out = r.In.Quote()
 	}
 }

--- a/internal/mode/validate/error.go
+++ b/internal/mode/validate/error.go
@@ -27,12 +27,8 @@ func (r *errorRenderer) VisitGenericError(err error) {
 	r.Schema.AcceptVisitor(r)
 }
 
-func (r *errorRenderer) VisitSet(s variable.Set) {
+func (r *errorRenderer) VisitBinary(s variable.Binary) {
 	r.Output.WriteString(r.Error.Unwrap().Error())
-}
-
-func (r *errorRenderer) VisitSetMembershipError(err variable.SetMembershipError) {
-	r.Output.WriteString(err.Error())
 }
 
 func (r *errorRenderer) VisitNumeric(s variable.Numeric) {
@@ -63,6 +59,14 @@ func (r *errorRenderer) VisitMinError(err variable.MinError) {
 }
 
 func (r *errorRenderer) VisitMaxError(err variable.MaxError) {
+	r.Output.WriteString(err.Error())
+}
+
+func (r *errorRenderer) VisitSet(s variable.Set) {
+	r.Output.WriteString(r.Error.Unwrap().Error())
+}
+
+func (r *errorRenderer) VisitSetMembershipError(err variable.SetMembershipError) {
 	r.Output.WriteString(err.Error())
 }
 

--- a/mode_dotenv_test.go
+++ b/mode_dotenv_test.go
@@ -18,7 +18,7 @@ func ExampleInit_exportDotEnvFile() {
 	os.Setenv("FERRITE_BINARY_SENSITIVE", "aHVudGVyMg==")
 	ferrite.
 		Binary("FERRITE_BINARY_SENSITIVE", "example sensitive binary").
-		WithDefaultString("password").
+		WithDefault([]byte("password")).
 		WithSensitiveContent().
 		Required()
 

--- a/mode_dotenv_test.go
+++ b/mode_dotenv_test.go
@@ -10,6 +10,18 @@ import (
 func ExampleInit_exportDotEnvFile() {
 	defer example()()
 
+	os.Setenv("FERRITE_BINARY", "PHZhbHVlPg==")
+	ferrite.
+		Binary("FERRITE_BINARY", "example binary").
+		Required()
+
+	os.Setenv("FERRITE_BINARY_SENSITIVE", "aHVudGVyMg==")
+	ferrite.
+		Binary("FERRITE_BINARY_SENSITIVE", "example sensitive binary").
+		WithDefaultString("password").
+		WithSensitiveContent().
+		Required()
+
 	os.Setenv("FERRITE_BOOL", "true")
 	ferrite.
 		Bool("FERRITE_BOOL", "example bool").
@@ -73,6 +85,12 @@ func ExampleInit_exportDotEnvFile() {
 	ferrite.Init()
 
 	// Output:
+	// # example binary (required)
+	// export FERRITE_BINARY=PHZhbHVlPg==
+	//
+	// # example sensitive binary (default: {12 bytes}, sensitive)
+	// export FERRITE_BINARY_SENSITIVE=aHVudGVyMg==
+	//
 	// # example bool (required)
 	// export FERRITE_BOOL=true
 	//

--- a/mode_validate_test.go
+++ b/mode_validate_test.go
@@ -11,6 +11,17 @@ import (
 func ExampleInit_validation() {
 	defer example()()
 
+	os.Setenv("FERRITE_BINARY", "PHZhbHVlPg==")
+	ferrite.
+		Binary("FERRITE_BINARY", "example binary").
+		Required()
+
+	os.Setenv("FERRITE_BINARY_SENSITIVE", "aHVudGVyMg==")
+	ferrite.
+		Binary("FERRITE_BINARY_SENSITIVE", "example sensitive binary").
+		WithSensitiveContent().
+		Required()
+
 	os.Setenv("FERRITE_BOOL", "true")
 	ferrite.
 		Bool("FERRITE_BOOL", "example bool").
@@ -78,6 +89,8 @@ func ExampleInit_validation() {
 	// Output:
 	// Environment Variables:
 	//
+	//    FERRITE_BINARY            example binary                           <base64>           ✓ set to {12 bytes}
+	//    FERRITE_BINARY_SENSITIVE  example sensitive binary                 <base64>           ✓ set to {12 bytes}
 	//    FERRITE_BOOL              example bool                             true | false       ✓ set to true
 	//    FERRITE_DURATION          example duration                         1ns ...            ✓ set to 3h20m
 	//    FERRITE_ENUM              example enum                             foo | bar | baz    ✓ set to foo
@@ -99,6 +112,17 @@ func ExampleInit_validationWithDefaultValues() {
 	defer example()()
 
 	ferrite.
+		Binary("FERRITE_BINARY", "example binary").
+		WithDefaultString("PHZhbHVlPg==").
+		Required()
+
+	ferrite.
+		Binary("FERRITE_BINARY_SENSITIVE", "example sensitive binary").
+		WithDefaultString("aHVudGVyMg==").
+		WithSensitiveContent().
+		Required()
+
+	ferrite.
 		Bool("FERRITE_BOOL", "example bool").
 		WithDefault(true).
 		Required()
@@ -106,7 +130,7 @@ func ExampleInit_validationWithDefaultValues() {
 	ferrite.
 		Duration("FERRITE_DURATION", "example duration").
 		WithDefault(10 * time.Second).
-		Optional()
+		Required()
 
 	ferrite.
 		Enum("FERRITE_ENUM", "example enum").
@@ -132,7 +156,7 @@ func ExampleInit_validationWithDefaultValues() {
 	ferrite.
 		Unsigned[uint16]("FERRITE_NUM_UNSIGNED", "example unsigned integer").
 		WithDefault(123).
-		Optional()
+		Required()
 
 	ferrite.
 		String("FERRITE_STRING", "example string").
@@ -148,7 +172,7 @@ func ExampleInit_validationWithDefaultValues() {
 	ferrite.
 		KubernetesService("ferrite-svc").
 		WithDefault("host.example.org", "443").
-		Optional()
+		Required()
 
 	ferrite.
 		URL("FERRITE_URL", "example URL").
@@ -164,6 +188,8 @@ func ExampleInit_validationWithDefaultValues() {
 	// Output:
 	// Environment Variables:
 	//
+	//    FERRITE_BINARY            example binary                         [ <base64> ] = {16 bytes}           ✓ using default value
+	//    FERRITE_BINARY_SENSITIVE  example sensitive binary               [ <base64> ] = {16 bytes}           ✓ using default value
 	//    FERRITE_BOOL              example bool                           [ true | false ] = true             ✓ using default value
 	//    FERRITE_DURATION          example duration                       [ 1ns ... ] = 10s                   ✓ using default value
 	//    FERRITE_ENUM              example enum                           [ foo | bar | baz ] = bar           ✓ using default value
@@ -183,6 +209,15 @@ func ExampleInit_validationWithDefaultValues() {
 
 func ExampleInit_validationWithOptionalValues() {
 	defer example()()
+
+	ferrite.
+		Binary("FERRITE_BINARY", "example binary").
+		Optional()
+
+	ferrite.
+		Binary("FERRITE_BINARY_SENSITIVE", "example sensitive binary").
+		WithSensitiveContent().
+		Optional()
 
 	ferrite.
 		Bool("FERRITE_BOOL", "example bool").
@@ -239,6 +274,8 @@ func ExampleInit_validationWithOptionalValues() {
 	// Output:
 	// Environment Variables:
 	//
+	//    FERRITE_BINARY            example binary                         [ <base64> ]         • undefined
+	//    FERRITE_BINARY_SENSITIVE  example sensitive binary               [ <base64> ]         • undefined
 	//    FERRITE_BOOL              example bool                           [ true | false ]     • undefined
 	//    FERRITE_DURATION          example duration                       [ 1ns ... ]          • undefined
 	//    FERRITE_ENUM              example enum                           [ foo | bar | baz ]  • undefined
@@ -281,6 +318,17 @@ func ExampleInit_validationWithNonCanonicalValues() {
 
 func ExampleInit_validationWithInvalidValues() {
 	defer example()()
+
+	os.Setenv("FERRITE_BINARY", "<invalid base64>")
+	ferrite.
+		Binary("FERRITE_BINARY", "example binary").
+		Required()
+
+	os.Setenv("FERRITE_BINARY_SENSITIVE", "<invalid base64>")
+	ferrite.
+		Binary("FERRITE_BINARY_SENSITIVE", "example sensitive binary").
+		WithSensitiveContent().
+		Required()
 
 	os.Setenv("FERRITE_BOOL", "yes")
 	ferrite.
@@ -339,7 +387,7 @@ func ExampleInit_validationWithInvalidValues() {
 			},
 		).
 		WithSensitiveContent().
-		Optional()
+		Required()
 
 	os.Setenv("FERRITE_SVC_SERVICE_HOST", ".local")
 	os.Setenv("FERRITE_SVC_SERVICE_PORT", "https-")
@@ -357,6 +405,8 @@ func ExampleInit_validationWithInvalidValues() {
 	// Output:
 	// Environment Variables:
 	//
+	//  ❯ FERRITE_BINARY            example binary                           <base64>           ✗ set to {16 bytes}, illegal base64 data at input byte 0
+	//  ❯ FERRITE_BINARY_SENSITIVE  example sensitive binary                 <base64>           ✗ set to {16 bytes}, illegal base64 data at input byte 0
 	//  ❯ FERRITE_BOOL              example bool                             true | false       ✗ set to yes, expected either true or false
 	//  ❯ FERRITE_DURATION          example duration                         1ns ...            ✗ set to -+10s, expected duration
 	//  ❯ FERRITE_ENUM              example enum                             foo | bar | baz    ✗ set to qux, expected foo, bar or baz
@@ -365,7 +415,7 @@ func ExampleInit_validationWithInvalidValues() {
 	//  ❯ FERRITE_NUM_SIGNED        example signed integer                   <int16>            ✗ set to 123.3, expected integer between -32768 and +32767
 	//  ❯ FERRITE_NUM_UNSIGNED      example unsigned integer                 <uint16>           ✗ set to -123, expected integer between 0 and 65535
 	//  ❯ FERRITE_STRING            example string                           <string>           ✗ set to 'foo bar', must not contain whitespace
-	//  ❯ FERRITE_STRING_SENSITIVE  example sensitive string               [ <string> ]         ✗ set to *******, must not contain whitespace
+	//  ❯ FERRITE_STRING_SENSITIVE  example sensitive string                 <string>           ✗ set to *******, must not contain whitespace
 	//  ❯ FERRITE_SVC_SERVICE_HOST  kubernetes "ferrite-svc" service host    <string>           ✗ set to .local, host must not begin or end with a dot
 	//  ❯ FERRITE_SVC_SERVICE_PORT  kubernetes "ferrite-svc" service port    <string>           ✗ set to https-, IANA service name must not begin or end with a hyphen
 	//  ❯ FERRITE_URL               example URL                              <string>           ✗ set to /relative/path, URL must have a scheme

--- a/mode_validate_test.go
+++ b/mode_validate_test.go
@@ -113,12 +113,12 @@ func ExampleInit_validationWithDefaultValues() {
 
 	ferrite.
 		Binary("FERRITE_BINARY", "example binary").
-		WithDefaultString("PHZhbHVlPg==").
+		WithEncodedDefault("PHZhbHVlPg==").
 		Required()
 
 	ferrite.
 		Binary("FERRITE_BINARY_SENSITIVE", "example sensitive binary").
-		WithDefaultString("aHVudGVyMg==").
+		WithEncodedDefault("aHVudGVyMg==").
 		WithSensitiveContent().
 		Required()
 
@@ -188,8 +188,8 @@ func ExampleInit_validationWithDefaultValues() {
 	// Output:
 	// Environment Variables:
 	//
-	//    FERRITE_BINARY            example binary                         [ <base64> ] = {16 bytes}           ✓ using default value
-	//    FERRITE_BINARY_SENSITIVE  example sensitive binary               [ <base64> ] = {16 bytes}           ✓ using default value
+	//    FERRITE_BINARY            example binary                         [ <base64> ] = {12 bytes}           ✓ using default value
+	//    FERRITE_BINARY_SENSITIVE  example sensitive binary               [ <base64> ] = {12 bytes}           ✓ using default value
 	//    FERRITE_BOOL              example bool                           [ true | false ] = true             ✓ using default value
 	//    FERRITE_DURATION          example duration                       [ 1ns ... ] = 10s                   ✓ using default value
 	//    FERRITE_ENUM              example enum                           [ foo | bar | baz ] = bar           ✓ using default value

--- a/variable/error.go
+++ b/variable/error.go
@@ -1,5 +1,7 @@
 package variable
 
+import "fmt"
+
 // Error is an error that indicates a problem parsing or validating an
 // environment variable.
 type Error interface {
@@ -7,4 +9,67 @@ type Error interface {
 
 	// Name returns the name of the environment variable.
 	Name() string
+}
+
+// MinLengthError indicates that a value was shorter than the minimum permitted
+// length.
+type MinLengthError struct {
+	ViolatedSchema LengthLimited
+}
+
+var _ SchemaError = MinLengthError{}
+
+// Schema returns the schema that was violated.
+func (e MinLengthError) Schema() Schema {
+	return e.ViolatedSchema
+}
+
+// AcceptVisitor passes the error to the appropriate method of v.
+func (e MinLengthError) AcceptVisitor(v SchemaErrorVisitor) {
+	v.VisitMinLengthError(e)
+}
+
+func (e MinLengthError) Error() string {
+	return fmt.Sprintf("too short, %s", explainLengthError(e.ViolatedSchema))
+}
+
+// MaxLengthError indicates that a value was greater than the maximum permitted
+// length.
+type MaxLengthError struct {
+	ViolatedSchema LengthLimited
+}
+
+var _ SchemaError = MaxLengthError{}
+
+// Schema returns the schema that was violated.
+func (e MaxLengthError) Schema() Schema {
+	return e.ViolatedSchema
+}
+
+// AcceptVisitor passes the error to the appropriate method of v.
+func (e MaxLengthError) AcceptVisitor(v SchemaErrorVisitor) {
+	v.VisitMaxLengthError(e)
+}
+
+func (e MaxLengthError) Error() string {
+	return fmt.Sprintf("too long, %s", explainLengthError(e.ViolatedSchema))
+}
+
+func explainLengthError(s LengthLimited) string {
+	min, hasMin := s.MinLengthNative()
+	max, hasMax := s.MaxLengthNative()
+
+	if !hasMin {
+		return fmt.Sprintf("expected length to be %d bytes or fewer", max)
+	}
+
+	if !hasMax {
+		return fmt.Sprintf("expected length to be %d bytes or more", max)
+	}
+
+	if min == max {
+		return fmt.Sprintf("expected length to be exactly %d bytes", min)
+	}
+
+	return fmt.Sprintf("expected length to be between %d and %d bytes", min, max)
 }

--- a/variable/error.go
+++ b/variable/error.go
@@ -56,8 +56,8 @@ func (e MaxLengthError) Error() string {
 }
 
 func explainLengthError(s LengthLimited) string {
-	min, hasMin := s.MinLengthNative()
-	max, hasMax := s.MaxLengthNative()
+	min, hasMin := s.MinLength()
+	max, hasMax := s.MaxLength()
 
 	if !hasMin {
 		return fmt.Sprintf("expected length to be %d bytes or fewer", max)

--- a/variable/schema.go
+++ b/variable/schema.go
@@ -23,19 +23,11 @@ type Schema interface {
 type LengthLimited interface {
 	Schema
 
-	// MinLengthLiteral returns the minimum permitted length of the literal
-	// environment variable value, in bytes.
-	MinLengthLiteral() (int, bool)
+	// MinLength returns the minimum permitted length of the native value.
+	MinLength() (int, bool)
 
-	// MaxLengthLiteral returns the maximum permitted length of the literal
-	// environment variable value, in bytes.
-	MaxLengthLiteral() (int, bool)
-
-	// MinLengthNative returns the minimum permitted length of the native value.
-	MinLengthNative() (int, bool)
-
-	// MaxLengthNative returns the maximum permitted length of the native value.
-	MaxLengthNative() (int, bool)
+	// MaxLength returns the maximum permitted length of the native value.
+	MaxLength() (int, bool)
 }
 
 // SchemaError indicates that a value is invalid because it violates its schema.

--- a/variable/schema.go
+++ b/variable/schema.go
@@ -51,6 +51,7 @@ type SchemaError interface {
 
 // SchemaVisitor dispatches based on a variable's schema.
 type SchemaVisitor interface {
+	VisitBinary(Binary)
 	VisitNumeric(Numeric)
 	VisitSet(Set)
 	VisitString(String)

--- a/variable/schema.go
+++ b/variable/schema.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 )
 
-// Schema describes the valid values of an environment value.
+// Schema describes the valid values of an environment variable value.
 type Schema interface {
 	// Type returns the type of the native value.
 	Type() reflect.Type
@@ -16,6 +16,26 @@ type Schema interface {
 
 	// AcceptVisitor passes the schema to the appropriate method of v.
 	AcceptVisitor(v SchemaVisitor)
+}
+
+// LengthLimited is an interface for a [Schema] that impose a minimum
+// and/or maximum length on an environment variable value.
+type LengthLimited interface {
+	Schema
+
+	// MinLengthLiteral returns the minimum permitted length of the literal
+	// environment variable value, in bytes.
+	MinLengthLiteral() (int, bool)
+
+	// MaxLengthLiteral returns the maximum permitted length of the literal
+	// environment variable value, in bytes.
+	MaxLengthLiteral() (int, bool)
+
+	// MinLengthNative returns the minimum permitted length of the native value.
+	MinLengthNative() (int, bool)
+
+	// MaxLengthNative returns the maximum permitted length of the native value.
+	MaxLengthNative() (int, bool)
 }
 
 // SchemaError indicates that a value is invalid because it violates its schema.

--- a/variable/schema_binary.go
+++ b/variable/schema_binary.go
@@ -18,79 +18,27 @@ type Binary interface {
 	EncodingDescription() string
 }
 
-// BinaryMarshaler is a Marshaler that encodes and decodes binary data.
-type BinaryMarshaler[T ~[]B, B ~byte] interface {
-	Marshaler[T]
-
-	// EncodingDescription returns a short (one word, ideally) human-readable
-	// description of the encoding scheme.
-	EncodingDescription() string
-
-	// EncodedLen returns the minimum and maximum length of the string that
-	// encodes n bytes of binary data.
-	EncodedLen(n int) (min, max int)
-}
-
 // TypedBinary is a string value depicted by type T.
 type TypedBinary[T ~[]B, B ~byte] struct {
-	Marshaler      BinaryMarshaler[T, B]
+	Marshaler      Marshaler[T]
 	MinLen, MaxLen maybe.Value[int]
+	EncodingDesc   string
 }
 
-// MinLengthLiteral returns the minimum permitted length of the literal
-// environment variable value, in bytes.
-func (s TypedBinary[T, B]) MinLengthLiteral() (int, bool) {
-	if min, ok := s.MinLengthNative(); ok {
-		min, _ = s.Marshaler.EncodedLen(min)
-		return min, true
-	}
-	return 0, false
-}
-
-// MaxLengthLiteral returns the maximum permitted length of the literal
-// environment variable value, in bytes.
-func (s TypedBinary[T, B]) MaxLengthLiteral() (int, bool) {
-	if max, ok := s.MaxLengthNative(); ok {
-		_, max = s.Marshaler.EncodedLen(max)
-		return max, true
-	}
-	return 0, false
-}
-
-// MinLengthNative returns the minimum permitted length of the native value.
-func (s TypedBinary[T, B]) MinLengthNative() (int, bool) {
+// MinLength returns the minimum permitted length of the native value.
+func (s TypedBinary[T, B]) MinLength() (int, bool) {
 	return s.MinLen.Get()
 }
 
-// MaxLengthNative returns the maximum permitted length of the native value.
-func (s TypedBinary[T, B]) MaxLengthNative() (int, bool) {
+// MaxLength returns the maximum permitted length of the native value.
+func (s TypedBinary[T, B]) MaxLength() (int, bool) {
 	return s.MaxLen.Get()
-}
-
-// MinLengthEncoded returns the minimum permitted length of the encoded
-// data, in bytes.
-func (s TypedBinary[T, B]) MinLengthEncoded() (int, bool) {
-	if min, ok := s.MinLen.Get(); ok {
-		min, _ = s.Marshaler.EncodedLen(min)
-		return min, true
-	}
-	return 0, false
-}
-
-// MaxLengthEncoded returns the maximum permitted length of the encoded
-// data, in bytes.
-func (s TypedBinary[T, B]) MaxLengthEncoded() (int, bool) {
-	if max, ok := s.MaxLen.Get(); ok {
-		max, _ = s.Marshaler.EncodedLen(max)
-		return max, true
-	}
-	return 0, false
 }
 
 // EncodingDescription returns a short (one word, ideally) human-readable
 // description of the encoding scheme.
 func (s TypedBinary[T, B]) EncodingDescription() string {
-	return s.Marshaler.EncodingDescription()
+	return s.EncodingDesc
 }
 
 // Type returns the type of the native value.

--- a/variable/schema_binary.go
+++ b/variable/schema_binary.go
@@ -1,0 +1,190 @@
+package variable
+
+import (
+	"fmt"
+	"math/rand"
+	"reflect"
+
+	"github.com/dogmatiq/ferrite/internal/reflectx"
+	"github.com/dogmatiq/ferrite/maybe"
+)
+
+// Binary is a schema that allows input of binary data.
+type Binary interface {
+	LengthLimited
+
+	// EncodingDescription returns a short (one word, ideally) human-readable
+	// description of the encoding scheme.
+	EncodingDescription() string
+}
+
+// BinaryMarshaler is a Marshaler that encodes and decodes binary data.
+type BinaryMarshaler[T ~[]B, B ~byte] interface {
+	Marshaler[T]
+
+	// EncodingDescription returns a short (one word, ideally) human-readable
+	// description of the encoding scheme.
+	EncodingDescription() string
+
+	// EncodedLen returns the minimum and maximum length of the string that
+	// encodes n bytes of binary data.
+	EncodedLen(n int) (min, max int)
+}
+
+// TypedBinary is a string value depicted by type T.
+type TypedBinary[T ~[]B, B ~byte] struct {
+	Marshaler      BinaryMarshaler[T, B]
+	MinLen, MaxLen maybe.Value[int]
+}
+
+// MinLengthLiteral returns the minimum permitted length of the literal
+// environment variable value, in bytes.
+func (s TypedBinary[T, B]) MinLengthLiteral() (int, bool) {
+	if min, ok := s.MinLengthNative(); ok {
+		min, _ = s.Marshaler.EncodedLen(min)
+		return min, true
+	}
+	return 0, false
+}
+
+// MaxLengthLiteral returns the maximum permitted length of the literal
+// environment variable value, in bytes.
+func (s TypedBinary[T, B]) MaxLengthLiteral() (int, bool) {
+	if max, ok := s.MaxLengthNative(); ok {
+		_, max = s.Marshaler.EncodedLen(max)
+		return max, true
+	}
+	return 0, false
+}
+
+// MinLengthNative returns the minimum permitted length of the native value.
+func (s TypedBinary[T, B]) MinLengthNative() (int, bool) {
+	return s.MinLen.Get()
+}
+
+// MaxLengthNative returns the maximum permitted length of the native value.
+func (s TypedBinary[T, B]) MaxLengthNative() (int, bool) {
+	return s.MaxLen.Get()
+}
+
+// MinLengthEncoded returns the minimum permitted length of the encoded
+// data, in bytes.
+func (s TypedBinary[T, B]) MinLengthEncoded() (int, bool) {
+	if min, ok := s.MinLen.Get(); ok {
+		min, _ = s.Marshaler.EncodedLen(min)
+		return min, true
+	}
+	return 0, false
+}
+
+// MaxLengthEncoded returns the maximum permitted length of the encoded
+// data, in bytes.
+func (s TypedBinary[T, B]) MaxLengthEncoded() (int, bool) {
+	if max, ok := s.MaxLen.Get(); ok {
+		max, _ = s.Marshaler.EncodedLen(max)
+		return max, true
+	}
+	return 0, false
+}
+
+// EncodingDescription returns a short (one word, ideally) human-readable
+// description of the encoding scheme.
+func (s TypedBinary[T, B]) EncodingDescription() string {
+	return s.Marshaler.EncodingDescription()
+}
+
+// Type returns the type of the native value.
+func (s TypedBinary[T, B]) Type() reflect.Type {
+	return reflectx.TypeOf[T]()
+}
+
+// Finalize prepares the schema for use.
+//
+// It returns an error if schema is invalid.
+func (s TypedBinary[T, B]) Finalize() error {
+	min := 1
+
+	if v, ok := s.MinLen.Get(); ok {
+		if v < min {
+			return fmt.Errorf("minimum length: must be at least %d", min)
+		}
+		min = v
+	}
+
+	if v, ok := s.MaxLen.Get(); ok {
+		if v < min {
+			return fmt.Errorf("maximum length: must be at least %d", min)
+		}
+	}
+
+	return nil
+}
+
+// AcceptVisitor passes s to the appropriate method of v.
+func (s TypedBinary[T, B]) AcceptVisitor(v SchemaVisitor) {
+	v.VisitBinary(s)
+}
+
+// Marshal converts a value to its literal representation.
+func (s TypedBinary[T, B]) Marshal(v T) (Literal, error) {
+	if err := s.validate(v); err != nil {
+		return Literal{}, err
+	}
+
+	return s.Marshaler.Marshal(v)
+}
+
+// Unmarshal converts a literal value to it's native representation.
+func (s TypedBinary[T, B]) Unmarshal(v Literal) (T, error) {
+	n, err := s.Marshaler.Unmarshal(v)
+	if err != nil {
+		return nil, err
+	}
+
+	return n, s.validate(n)
+}
+
+// Examples returns a (possibly empty) set of examples of valid values.
+func (s TypedBinary[T, B]) Examples(hasOtherExamples bool) []TypedExample[T] {
+	if hasOtherExamples {
+		return nil
+	}
+
+	size, ok := s.MinLen.Get()
+	if !ok {
+		size = 16
+
+		if max, ok := s.MaxLen.Get(); ok {
+			if size > max {
+				size = max
+			}
+		}
+	}
+
+	example := make(T, size)
+
+	// Use a *deterministic* random value to as the example.
+	src := rand.NewSource(int64(size))
+	for i := range example {
+		example[i] = B(src.Int63())
+	}
+
+	return []TypedExample[T]{
+		{
+			Native: example,
+		},
+	}
+}
+
+// validate returns an error if v is invalid.
+func (s TypedBinary[T, B]) validate(v T) error {
+	if min, ok := s.MinLen.Get(); ok && len(v) < min {
+		return MinLengthError{s}
+	}
+
+	if max, ok := s.MaxLen.Get(); ok && len(v) > max {
+		return MinLengthError{s}
+	}
+
+	return nil
+}

--- a/variable/schema_string.go
+++ b/variable/schema_string.go
@@ -19,25 +19,13 @@ type TypedString[T ~string] struct {
 	MinLen, MaxLen maybe.Value[int]
 }
 
-// MinLengthLiteral returns the minimum permitted length of the literal
-// environment variable value, in bytes.
-func (s TypedString[T]) MinLengthLiteral() (int, bool) {
-	return s.MinLengthNative()
-}
-
-// MaxLengthLiteral returns the maximum permitted length of the literal
-// environment variable value, in bytes.
-func (s TypedString[T]) MaxLengthLiteral() (int, bool) {
-	return s.MaxLengthNative()
-}
-
-// MinLengthNative returns the minimum permitted length of the native value.
-func (s TypedString[T]) MinLengthNative() (int, bool) {
+// MinLength returns the minimum permitted length of the native value.
+func (s TypedString[T]) MinLength() (int, bool) {
 	return s.MinLen.Get()
 }
 
-// MaxLengthNative returns the maximum permitted length of the native value.
-func (s TypedString[T]) MaxLengthNative() (int, bool) {
+// MaxLength returns the maximum permitted length of the native value.
+func (s TypedString[T]) MaxLength() (int, bool) {
 	return s.MaxLen.Get()
 }
 


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/blob/main/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR adds the `Binary()` and `BinaryAs()` variable builders.

#### Why make this change?

Binary values can be useful for communicating data such as SSH keys, hashes, etc.

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

Fixes #22, supersedes #65
