### PR TITLE
Re-resolve variables when environment changes

### DIFF
--- a/builder_string_test.go
+++ b/builder_string_test.go
@@ -125,6 +125,40 @@ var _ = Describe("type StringBuilder", func() {
 		})
 	})
 
+	It("re-resolves when the environment variable changes", func() {
+		os.Setenv("FERRITE_STRING", "<original>")
+
+		varset := builder.Required()
+		Expect(varset.Value()).To(Equal(userDefinedString("<original>")))
+
+		os.Setenv("FERRITE_STRING", "<changed>")
+		Expect(varset.Value()).To(Equal(userDefinedString("<changed>")))
+	})
+
+	It("re-resolves from set to unset", func() {
+		os.Setenv("FERRITE_STRING", "<value>")
+
+		varset := builder.Optional()
+		v, ok := varset.Value()
+		Expect(ok).To(BeTrue())
+		Expect(v).To(Equal(userDefinedString("<value>")))
+
+		os.Unsetenv("FERRITE_STRING")
+		_, ok = varset.Value()
+		Expect(ok).To(BeFalse())
+	})
+
+	It("re-resolves from unset to set", func() {
+		varset := builder.Optional()
+		_, ok := varset.Value()
+		Expect(ok).To(BeFalse())
+
+		os.Setenv("FERRITE_STRING", "<value>")
+		v, ok := varset.Value()
+		Expect(ok).To(BeTrue())
+		Expect(v).To(Equal(userDefinedString("<value>")))
+	})
+
 	When("the value is shorter than the minimum length", func() {
 		When("the limit is set using WithMinimumLength()", func() {
 			It("panics", func() {

--- a/internal/variable/variable.go
+++ b/internal/variable/variable.go
@@ -3,6 +3,7 @@ package variable
 import (
 	"fmt"
 	"sync"
+	"sync/atomic"
 
 	"github.com/dogmatiq/ferrite/internal/environment"
 )
@@ -60,7 +61,13 @@ type Any interface {
 type OfType[T any] struct {
 	TypedSpec *TypedSpec[T]
 
-	once         sync.Once
+	m          sync.Mutex
+	resolution atomic.Pointer[resolution[T]]
+}
+
+// resolution holds the cached result of resolving an environment variable.
+type resolution[T any] struct {
+	lit          string
 	availability Availability
 	source       Source
 	value        valueOf[T]
@@ -74,14 +81,12 @@ func (v *OfType[T]) Spec() Spec {
 
 // Availability returns the variable's availability.
 func (v *OfType[T]) Availability() Availability {
-	v.resolve()
-	return v.availability
+	return v.resolve().availability
 }
 
 // Source returns the source of the variable's value.
 func (v *OfType[T]) Source() Source {
-	v.resolve()
-	return v.source
+	return v.resolve().source
 }
 
 // Value returns the variable's value.
@@ -89,8 +94,7 @@ func (v *OfType[T]) Source() Source {
 // If no value is available it returns a zero-value. It is the caller's
 // responsibility to check the variable's availability before using the value.
 func (v *OfType[T]) Value() Value {
-	v.resolve()
-	return v.value
+	return v.resolve().value
 }
 
 // NativeValue returns the variable's value.
@@ -98,8 +102,7 @@ func (v *OfType[T]) Value() Value {
 // If no value is available it returns a zero-value. It is the caller's
 // responsibility to check the variable's availability before using the value.
 func (v *OfType[T]) NativeValue() T {
-	v.resolve()
-	return v.value.native
+	return v.resolve().value.native
 }
 
 // Error returns an error describing the variable's state.
@@ -111,59 +114,70 @@ func (v *OfType[T]) NativeValue() T {
 // has an availability of AvailabilityOK, or if it has an availability of
 // AvailabilityNone and v.Spec().IsRequired() is false.
 func (v *OfType[T]) Error() Error {
-	v.resolve()
-	return v.err
+	return v.resolve().err
 }
 
-func (v *OfType[T]) resolve() {
-	v.once.Do(func() {
-		// Override the availability to AvailabilityIgnored if any of the
-		// preconditions fail.
-		defer func() {
-			for _, fn := range v.TypedSpec.preconditions {
-				if !fn() {
-					v.availability = AvailabilityIgnored
-					break
-				}
-			}
-		}()
+func (v *OfType[T]) resolve() *resolution[T] {
+	lit := environment.Get(v.TypedSpec.name)
 
-		lit := Literal{
-			String: environment.Get(v.TypedSpec.name),
+	if r := v.resolution.Load(); r != nil {
+		if r.lit == lit {
+			return r
 		}
+	}
 
-		if lit.String == "" {
-			if def, ok := v.TypedSpec.def.Get(); ok {
-				v.availability = AvailabilityOK
-				v.source = SourceDefault
-				v.value = def
-			} else if v.TypedSpec.required {
-				v.availability = AvailabilityNone
-				v.err = undefinedError{v.TypedSpec.Name()}
-			}
-			return
+	v.m.Lock()
+	defer v.m.Unlock()
+
+	if r := v.resolution.Load(); r != nil {
+		if r.lit == lit {
+			return r
 		}
+	}
 
-		v.source = SourceEnvironment
+	r := &resolution[T]{
+		lit: lit,
+	}
 
-		n, c, err := v.TypedSpec.Unmarshal(ConstraintContextFinal, lit)
+	if lit == "" {
+		if def, ok := v.TypedSpec.def.Get(); ok {
+			r.availability = AvailabilityOK
+			r.source = SourceDefault
+			r.value = def
+		} else if v.TypedSpec.required {
+			r.availability = AvailabilityNone
+			r.err = undefinedError{v.TypedSpec.Name()}
+		}
+	} else {
+		r.source = SourceEnvironment
+
+		n, c, err := v.TypedSpec.Unmarshal(ConstraintContextFinal, Literal{String: lit})
 		if err != nil {
-			v.availability = AvailabilityInvalid
-			v.err = valueError{
+			r.availability = AvailabilityInvalid
+			r.err = valueError{
 				name:    v.TypedSpec.name,
-				literal: lit,
+				literal: Literal{String: lit},
 				cause:   err,
 			}
-			return
+		} else {
+			r.availability = AvailabilityOK
+			r.value = valueOf[T]{
+				verbatim:  Literal{String: lit},
+				native:    n,
+				canonical: c,
+			}
 		}
+	}
 
-		v.availability = AvailabilityOK
-		v.value = valueOf[T]{
-			verbatim:  lit,
-			native:    n,
-			canonical: c,
+	for _, fn := range v.TypedSpec.preconditions {
+		if !fn() {
+			r.availability = AvailabilityIgnored
+			break
 		}
-	})
+	}
+
+	v.resolution.Store(r)
+	return r
 }
 
 // undefinedError is an Error that indicates that a variable is undefined and

--- a/internal/variable/variable.go
+++ b/internal/variable/variable.go
@@ -67,11 +67,10 @@ type OfType[T any] struct {
 
 // resolution holds the cached result of resolving an environment variable.
 type resolution[T any] struct {
-	lit          string
-	availability Availability
-	source       Source
-	value        valueOf[T]
-	err          Error
+	lit    string
+	source Source
+	value  valueOf[T]
+	err    Error
 }
 
 // Spec returns the variable's specification.
@@ -81,7 +80,23 @@ func (v *OfType[T]) Spec() Spec {
 
 // Availability returns the variable's availability.
 func (v *OfType[T]) Availability() Availability {
-	return v.resolve().availability
+	for _, fn := range v.TypedSpec.preconditions {
+		if !fn() {
+			return AvailabilityIgnored
+		}
+	}
+
+	r := v.resolve()
+
+	if _, ok := r.err.(valueError); ok {
+		return AvailabilityInvalid
+	}
+
+	if r.source == SourceNone {
+		return AvailabilityNone
+	}
+
+	return AvailabilityOK
 }
 
 // Source returns the source of the variable's value.
@@ -141,11 +156,9 @@ func (v *OfType[T]) resolve() *resolution[T] {
 
 	if lit == "" {
 		if def, ok := v.TypedSpec.def.Get(); ok {
-			r.availability = AvailabilityOK
 			r.source = SourceDefault
 			r.value = def
 		} else if v.TypedSpec.required {
-			r.availability = AvailabilityNone
 			r.err = undefinedError{v.TypedSpec.Name()}
 		}
 	} else {
@@ -153,26 +166,17 @@ func (v *OfType[T]) resolve() *resolution[T] {
 
 		n, c, err := v.TypedSpec.Unmarshal(ConstraintContextFinal, Literal{String: lit})
 		if err != nil {
-			r.availability = AvailabilityInvalid
 			r.err = valueError{
 				name:    v.TypedSpec.name,
 				literal: Literal{String: lit},
 				cause:   err,
 			}
 		} else {
-			r.availability = AvailabilityOK
 			r.value = valueOf[T]{
 				verbatim:  Literal{String: lit},
 				native:    n,
 				canonical: c,
 			}
-		}
-	}
-
-	for _, fn := range v.TypedSpec.preconditions {
-		if !fn() {
-			r.availability = AvailabilityIgnored
-			break
 		}
 	}
 

--- a/internal/variable/variable.go
+++ b/internal/variable/variable.go
@@ -88,7 +88,7 @@ func (v *OfType[T]) Availability() Availability {
 
 	r := v.resolve()
 
-	if _, ok := r.err.(valueError); ok {
+	if _, ok := r.err.(ValueError); ok {
 		return AvailabilityInvalid
 	}
 


### PR DESCRIPTION
Replace the `sync.Once` caching in variable resolution with an `atomic.Pointer` to an immutable resolution snapshot. On each access, the current environment value is compared to the value used in the last resolution. If unchanged, the cached result is returned without locking or re-parsing.

This allows `t.Setenv()` to work naturally in tests without any special helpers or test-specific behavior. The resolution is re-triggered automatically when the environment value differs from what was last resolved.

Fixes #186