### PR TITLE
Add AnyAs[T]() builder for user-defined types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Added `AnyAs[T]()` builder for environment variables that are parsed into
+  arbitrary user-defined types using caller-supplied marshal/unmarshal functions.
+
 ### Fixed
 
 - Environment variable values are now re-resolved when the environment changes,

--- a/builder_anyas.go
+++ b/builder_anyas.go
@@ -1,0 +1,116 @@
+package ferrite
+
+import (
+	"github.com/dogmatiq/ferrite/internal/variable"
+)
+
+// AnyAs configures an environment variable that is parsed from a string into an
+// arbitrary type using a user-supplied parse function.
+//
+// name is the name of the environment variable to read. desc is a
+// human-readable description of the environment variable.
+//
+// unmarshal is called to convert the environment variable's string value into T.
+// If it returns an error, the value is considered invalid.
+//
+// marshal is called to convert a T value back to its string representation.
+// It is used to render defaults and examples in validation output.
+func AnyAs[T any](
+	name, desc string,
+	unmarshal func(string) (T, error),
+	marshal func(T) (string, error),
+) *AnyAsBuilder[T] {
+	b := &AnyAsBuilder[T]{
+		schema: variable.TypedOther[T]{
+			Marshaler: anyAsMarshaler[T]{unmarshal, marshal},
+		},
+	}
+
+	b.builder.Name(name)
+	b.builder.Description(desc)
+
+	return b
+}
+
+// AnyAsBuilder builds a specification for a variable of an arbitrary type that
+// is parsed from a string using a user-supplied function.
+type AnyAsBuilder[T any] struct {
+	schema  variable.TypedOther[T]
+	builder variable.TypedSpecBuilder[T]
+}
+
+var _ isBuilderOf[
+	any,
+	any,
+	*AnyAsBuilder[any],
+]
+
+// WithDefault sets the default value of the variable.
+//
+// It is used when the environment variable is undefined or empty.
+func (b *AnyAsBuilder[T]) WithDefault(v T) *AnyAsBuilder[T] {
+	b.builder.Default(v)
+	return b
+}
+
+// WithExample adds an example value to the variable's documentation.
+func (b *AnyAsBuilder[T]) WithExample(v T, desc string) *AnyAsBuilder[T] {
+	b.builder.NormativeExample(v, desc)
+	return b
+}
+
+// WithConstraint adds a constraint to the variable.
+//
+// fn is called with the environment variable value after it is parsed. If fn
+// returns false the value is considered invalid.
+func (b *AnyAsBuilder[T]) WithConstraint(
+	desc string,
+	fn func(T) bool,
+) *AnyAsBuilder[T] {
+	b.builder.UserConstraint(desc, fn)
+	return b
+}
+
+// WithSensitiveContent marks the variable as containing sensitive content.
+//
+// Values of sensitive variables are not printed to the console or included in
+// generated documentation.
+func (b *AnyAsBuilder[T]) WithSensitiveContent() *AnyAsBuilder[T] {
+	b.builder.MarkSensitive()
+	return b
+}
+
+// Required completes the build process and registers a required variable with
+// Ferrite's validation system.
+func (b *AnyAsBuilder[T]) Required(options ...RequiredOption) Required[T] {
+	return required(b.schema, &b.builder, options...)
+}
+
+// Optional completes the build process and registers an optional variable with
+// Ferrite's validation system.
+func (b *AnyAsBuilder[T]) Optional(options ...OptionalOption) Optional[T] {
+	return optional(b.schema, &b.builder, options...)
+}
+
+// Deprecated completes the build process and registers a deprecated variable
+// with Ferrite's validation system.
+func (b *AnyAsBuilder[T]) Deprecated(options ...DeprecatedOption) Deprecated[T] {
+	return deprecated(b.schema, &b.builder, options...)
+}
+
+type anyAsMarshaler[T any] struct {
+	unmarshal func(string) (T, error)
+	marshal   func(T) (string, error)
+}
+
+func (m anyAsMarshaler[T]) Marshal(v T) (variable.Literal, error) {
+	s, err := m.marshal(v)
+	if err != nil {
+		return variable.Literal{}, err
+	}
+	return variable.Literal{String: s}, nil
+}
+
+func (m anyAsMarshaler[T]) Unmarshal(v variable.Literal) (T, error) {
+	return m.unmarshal(v.String)
+}

--- a/builder_anyas.go
+++ b/builder_anyas.go
@@ -1,6 +1,8 @@
 package ferrite
 
 import (
+	"fmt"
+
 	"github.com/dogmatiq/ferrite/internal/variable"
 )
 
@@ -131,7 +133,7 @@ func (m anyAsMarshaler[T]) Unmarshal(v variable.Literal) (T, error) {
 	// unmarshal accepts values that marshal can't represent, so we check here
 	// to surface that as a validation error rather than a panic.
 	if _, err := m.marshal(n); err != nil {
-		return n, err
+		return n, fmt.Errorf("value cannot be marshaled: %w", err)
 	}
 
 	return n, nil

--- a/builder_anyas.go
+++ b/builder_anyas.go
@@ -4,8 +4,8 @@ import (
 	"github.com/dogmatiq/ferrite/internal/variable"
 )
 
-// AnyAs configures an environment variable that is parsed from a string into an
-// arbitrary type using a user-supplied parse function.
+// AnyAs configures an environment variable as a value of type T, using
+// caller-supplied functions to marshal and unmarshal the value.
 //
 // name is the name of the environment variable to read. desc is a
 // human-readable description of the environment variable.
@@ -20,6 +20,13 @@ func AnyAs[T any](
 	unmarshal func(string) (T, error),
 	marshal func(T) (string, error),
 ) *AnyAsBuilder[T] {
+	if unmarshal == nil {
+		panic("AnyAs: unmarshal function must not be nil")
+	}
+	if marshal == nil {
+		panic("AnyAs: marshal function must not be nil")
+	}
+
 	b := &AnyAsBuilder[T]{
 		schema: variable.TypedOther[T]{
 			Marshaler: anyAsMarshaler[T]{unmarshal, marshal},

--- a/builder_anyas.go
+++ b/builder_anyas.go
@@ -1,8 +1,6 @@
 package ferrite
 
 import (
-	"fmt"
-
 	"github.com/dogmatiq/ferrite/internal/variable"
 )
 
@@ -133,7 +131,7 @@ func (m anyAsMarshaler[T]) Unmarshal(v variable.Literal) (T, error) {
 	// unmarshal accepts values that marshal can't represent, so we check here
 	// to surface that as a validation error rather than a panic.
 	if _, err := m.marshal(n); err != nil {
-		return n, fmt.Errorf("value cannot be marshaled: %w", err)
+		return n, err
 	}
 
 	return n, nil

--- a/builder_anyas.go
+++ b/builder_anyas.go
@@ -39,8 +39,8 @@ func AnyAs[T any](
 	return b
 }
 
-// AnyAsBuilder builds a specification for a variable of an arbitrary type that
-// is parsed from a string using a user-supplied function.
+// AnyAsBuilder builds a specification for a variable of an arbitrary type,
+// using caller-supplied functions to marshal and unmarshal the value.
 type AnyAsBuilder[T any] struct {
 	schema  variable.TypedOther[T]
 	builder variable.TypedSpecBuilder[T]
@@ -119,5 +119,20 @@ func (m anyAsMarshaler[T]) Marshal(v T) (variable.Literal, error) {
 }
 
 func (m anyAsMarshaler[T]) Unmarshal(v variable.Literal) (T, error) {
-	return m.unmarshal(v.String)
+	n, err := m.unmarshal(v.String)
+	if err != nil {
+		return n, err
+	}
+
+	// Verify that the unmarshaled value can be round-tripped through the
+	// marshal function. [variable.TypedSpec] re-marshals every valid value to
+	// compute its canonical literal representation, and panics if marshaling
+	// fails. Since these are user-supplied functions, it's plausible that
+	// unmarshal accepts values that marshal can't represent, so we check here
+	// to surface that as a validation error rather than a panic.
+	if _, err := m.marshal(n); err != nil {
+		return n, err
+	}
+
+	return n, nil
 }

--- a/builder_anyas_test.go
+++ b/builder_anyas_test.go
@@ -54,6 +54,18 @@ var _ = Describe("type AnyAsBuilder", func() {
 		}).To(PanicWith("specification for FERRITE_ANY_AS is invalid: variable description must not be empty"))
 	})
 
+	It("panics if the unmarshal function is nil", func() {
+		Expect(func() {
+			AnyAs[uppercased]("FERRITE_ANY_AS", "<desc>", nil, formatUppercased)
+		}).To(PanicWith("AnyAs: unmarshal function must not be nil"))
+	})
+
+	It("panics if the marshal function is nil", func() {
+		Expect(func() {
+			AnyAs("FERRITE_ANY_AS", "<desc>", parseUppercased, nil)
+		}).To(PanicWith("AnyAs: marshal function must not be nil"))
+	})
+
 	When("the variable is required", func() {
 		When("the value is not empty", func() {
 			Describe("func Value()", func() {

--- a/builder_anyas_test.go
+++ b/builder_anyas_test.go
@@ -79,7 +79,7 @@ var _ = Describe("type AnyAsBuilder", func() {
 					Required().
 					Value()
 			}).To(PanicWith(
-				`value of FERRITE_ANY_AS (hello) is invalid: value cannot be marshaled: marshal failed`,
+				`value of FERRITE_ANY_AS (hello) is invalid: marshal failed`,
 			))
 		})
 	})

--- a/builder_anyas_test.go
+++ b/builder_anyas_test.go
@@ -66,6 +66,24 @@ var _ = Describe("type AnyAsBuilder", func() {
 		}).To(PanicWith("AnyAs: marshal function must not be nil"))
 	})
 
+	When("the value cannot be marshaled after unmarshaling", func() {
+		It("panics with a validation error", func() {
+			os.Setenv("FERRITE_ANY_AS", "hello")
+
+			marshal := func(v uppercased) (string, error) {
+				return "", errors.New("marshal failed")
+			}
+
+			Expect(func() {
+				AnyAs("FERRITE_ANY_AS", "<desc>", parseUppercased, marshal).
+					Required().
+					Value()
+			}).To(PanicWith(
+				`value of FERRITE_ANY_AS (hello) is invalid: value cannot be marshaled: marshal failed`,
+			))
+		})
+	})
+
 	When("the variable is required", func() {
 		When("the value is not empty", func() {
 			Describe("func Value()", func() {

--- a/builder_anyas_test.go
+++ b/builder_anyas_test.go
@@ -1,0 +1,221 @@
+package ferrite_test
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/dogmatiq/ferrite"
+	. "github.com/dogmatiq/ferrite"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// uppercased is a simple test type that wraps a string in uppercase form.
+type uppercased struct {
+	Value string
+}
+
+func parseUppercased(s string) (uppercased, error) {
+	if s == "" {
+		return uppercased{}, errors.New("must not be empty")
+	}
+	return uppercased{Value: strings.ToUpper(s)}, nil
+}
+
+func formatUppercased(v uppercased) (string, error) {
+	if v.Value == "" {
+		return "", errors.New("must not be empty")
+	}
+	return v.Value, nil
+}
+
+var _ = Describe("type AnyAsBuilder", func() {
+	var builder *AnyAsBuilder[uppercased]
+
+	BeforeEach(func() {
+		builder = AnyAs("FERRITE_ANY_AS", "<desc>", parseUppercased, formatUppercased)
+	})
+
+	AfterEach(func() {
+		tearDown()
+	})
+
+	It("panics if the name is empty", func() {
+		Expect(func() {
+			AnyAs("", "<desc>", parseUppercased, formatUppercased).Optional()
+		}).To(PanicWith("invalid specification: variable name must not be empty"))
+	})
+
+	It("panics if the description is empty", func() {
+		Expect(func() {
+			AnyAs("FERRITE_ANY_AS", "", parseUppercased, formatUppercased).Optional()
+		}).To(PanicWith("specification for FERRITE_ANY_AS is invalid: variable description must not be empty"))
+	})
+
+	When("the variable is required", func() {
+		When("the value is not empty", func() {
+			Describe("func Value()", func() {
+				It("returns the parsed value", func() {
+					os.Setenv("FERRITE_ANY_AS", "hello")
+
+					v := builder.
+						Required().
+						Value()
+
+					Expect(v).To(Equal(uppercased{Value: "HELLO"}))
+				})
+			})
+		})
+
+		When("the value is empty", func() {
+			When("there is a default value", func() {
+				Describe("func Value()", func() {
+					It("returns the default", func() {
+						v := builder.
+							WithDefault(uppercased{Value: "DEFAULT"}).
+							Required().
+							Value()
+
+						Expect(v).To(Equal(uppercased{Value: "DEFAULT"}))
+					})
+				})
+			})
+
+			When("there is no default value", func() {
+				Describe("func Value()", func() {
+					It("panics", func() {
+						Expect(func() {
+							builder.
+								Required().
+								Value()
+						}).To(PanicWith(
+							"FERRITE_ANY_AS is undefined and does not have a default value",
+						))
+					})
+				})
+			})
+		})
+	})
+
+	When("the variable is optional", func() {
+		When("the value is not empty", func() {
+			Describe("func Value()", func() {
+				It("returns the parsed value", func() {
+					os.Setenv("FERRITE_ANY_AS", "hello")
+
+					v, ok := builder.
+						Optional().
+						Value()
+
+					Expect(ok).To(BeTrue())
+					Expect(v).To(Equal(uppercased{Value: "HELLO"}))
+				})
+			})
+		})
+
+		When("the value is empty", func() {
+			When("there is a default value", func() {
+				Describe("func Value()", func() {
+					It("returns the default", func() {
+						v, ok := builder.
+							WithDefault(uppercased{Value: "DEFAULT"}).
+							Optional().
+							Value()
+
+						Expect(ok).To(BeTrue())
+						Expect(v).To(Equal(uppercased{Value: "DEFAULT"}))
+					})
+				})
+			})
+
+			When("there is no default value", func() {
+				Describe("func Value()", func() {
+					It("returns with ok == false", func() {
+						_, ok := builder.
+							Optional().
+							Value()
+
+						Expect(ok).To(BeFalse())
+					})
+				})
+			})
+		})
+	})
+})
+
+func ExampleAnyAs_required() {
+	defer example()()
+
+	v := ferrite.
+		AnyAs("FERRITE_ANY_AS", "example parsed variable", parseUppercased, formatUppercased).
+		Required()
+
+	os.Setenv("FERRITE_ANY_AS", "hello")
+	ferrite.Init()
+
+	fmt.Println("value is", v.Value().Value)
+
+	// Output:
+	// value is HELLO
+}
+
+func ExampleAnyAs_default() {
+	defer example()()
+
+	v := ferrite.
+		AnyAs("FERRITE_ANY_AS", "example parsed variable", parseUppercased, formatUppercased).
+		WithDefault(uppercased{Value: "DEFAULT"}).
+		Required()
+
+	ferrite.Init()
+
+	fmt.Println("value is", v.Value().Value)
+
+	// Output:
+	// value is DEFAULT
+}
+
+func ExampleAnyAs_optional() {
+	defer example()()
+
+	v := ferrite.
+		AnyAs("FERRITE_ANY_AS", "example parsed variable", parseUppercased, formatUppercased).
+		Optional()
+
+	ferrite.Init()
+
+	if x, ok := v.Value(); ok {
+		fmt.Println("value is", x.Value)
+	} else {
+		fmt.Println("value is undefined")
+	}
+
+	// Output:
+	// value is undefined
+}
+
+func ExampleAnyAs_constraint() {
+	defer example()()
+
+	ferrite.
+		AnyAs("FERRITE_ANY_AS", "example constrained parsed variable", parseUppercased, formatUppercased).
+		WithConstraint(
+			"must contain X",
+			func(v uppercased) bool {
+				return strings.Contains(v.Value, "X")
+			},
+		).
+		Required()
+
+	os.Setenv("FERRITE_ANY_AS", "hello")
+	ferrite.Init()
+
+	// Output:
+	// Environment Variables:
+	//
+	//  ❯ FERRITE_ANY_AS  example constrained parsed variable    <string>    ✗ set to hello, must contain X
+	//
+	// <process exited with error code 1>
+}


### PR DESCRIPTION
Closes #188.

Adds `AnyAs[T]()`, a generic builder that lets users define environment variables parsed into arbitrary types using caller-supplied marshal/unmarshal functions.

### API

```go
func AnyAs[T any](
    name, desc string,
    unmarshal func(string) (T, error),
    marshal func(T) (string, error),
) *AnyAsBuilder[T]
```

### Builder methods

- `WithDefault(v T)`
- `WithExample(v T, desc string)`
- `WithConstraint(desc string, fn func(T) bool)`
- `WithSensitiveContent()`
- `Required(...RequiredOption)`
- `Optional(...OptionalOption)`
- `Deprecated(...DeprecatedOption)`

### Implementation

Uses `TypedOther[T]` with an internal `anyAsMarshaler[T]` that wraps the user's two functions into the `variable.Marshaler[T]` interface. This is the same schema type used by `URLBuilder` and `NetworkAddressBuilder`.

### Naming

`AnyAs` follows the `{X}As[T]` pattern established by `StringAs[T ~string]`. The prefix describes the type constraint — `any` means the caller must supply the marshaling functions since no built-in behavior exists. This leaves room for future `TextAs[T]` (for `encoding.TextMarshaler` types) and `JSONAs[T]` variants.

### Example

```go
var envPersistenceURL = ferrite.
    AnyAs("PERSISTENCE_URL", "the URL of the persistence provider",
        persistence.NewProvider,    // unmarshal: string -> Provider
        persistence.FormatProvider, // marshal: Provider -> string
    ).
    Optional()
```