### PR TITLE
Add TextAs and TextAsP builders for encoding.TextMarshaler types

### DIFF
--- a/builder_text.go
+++ b/builder_text.go
@@ -1,0 +1,166 @@
+package ferrite
+
+import (
+	"encoding"
+
+	"github.com/dogmatiq/ferrite/internal/variable"
+)
+
+// TextAs configures an environment variable as a value of type T, which
+// implements [encoding.TextMarshaler] directly (via a value receiver) and
+// [encoding.TextUnmarshaler] via its pointer type P.
+//
+// The result type of the variable is T (the value type). Use [TextAsP] if T
+// only implements [encoding.TextMarshaler] via a pointer receiver, or if the
+// result type should be a pointer.
+func TextAs[
+	T encoding.TextMarshaler,
+	P interface {
+		*T
+		encoding.TextUnmarshaler
+	},
+](name, desc string) *TextAsBuilder[T] {
+	b := &TextAsBuilder[T]{
+		schema: variable.TypedOther[T]{
+			Marshaler: textMarshaler[T]{
+				marshal: T.MarshalText,
+				unmarshal: func(data []byte) (T, error) {
+					var v T
+					if err := P(&v).UnmarshalText(data); err != nil {
+						return v, err
+					}
+					return v, nil
+				},
+			},
+		},
+	}
+
+	b.builder.Name(name)
+	b.builder.Description(desc)
+
+	return b
+}
+
+// TextAsP configures an environment variable as a value of type P (a pointer
+// to T), which implements [encoding.TextMarshaler] and
+// [encoding.TextUnmarshaler].
+//
+// The result type of the variable is P (the pointer type). Use [TextAs] if the
+// result type should be T (the value type).
+func TextAsP[
+	T any,
+	P interface {
+		*T
+		encoding.TextMarshaler
+		encoding.TextUnmarshaler
+	},
+](name, desc string) *TextAsBuilder[P] {
+	b := &TextAsBuilder[P]{
+		schema: variable.TypedOther[P]{
+			Marshaler: textMarshaler[P]{
+				marshal: P.MarshalText,
+				unmarshal: func(data []byte) (P, error) {
+					v := P(new(T))
+					if err := v.UnmarshalText(data); err != nil {
+						return nil, err
+					}
+					return v, nil
+				},
+			},
+		},
+	}
+
+	b.builder.Name(name)
+	b.builder.Description(desc)
+
+	return b
+}
+
+// TextAsBuilder builds a specification for a variable that uses
+// [encoding.TextMarshaler] and [encoding.TextUnmarshaler] for marshaling.
+//
+// The interface constraints are enforced by the [TextAs] and [TextAsP]
+// constructors, not by this type. This allows both constructors to share a
+// single builder type without propagating the pointer type parameter.
+type TextAsBuilder[T any] struct {
+	schema  variable.TypedOther[T]
+	builder variable.TypedSpecBuilder[T]
+}
+
+var _ isBuilderOf[
+	any,
+	any,
+	*TextAsBuilder[any],
+]
+
+// WithDefault sets the default value of the variable.
+//
+// It is used when the environment variable is undefined or empty.
+func (b *TextAsBuilder[T]) WithDefault(v T) *TextAsBuilder[T] {
+	b.builder.Default(v)
+	return b
+}
+
+// WithExample adds an example value to the variable's documentation.
+func (b *TextAsBuilder[T]) WithExample(v T, desc string) *TextAsBuilder[T] {
+	b.builder.NormativeExample(v, desc)
+	return b
+}
+
+// WithConstraint adds a constraint to the variable.
+//
+// fn is called with the environment variable value after it is parsed. If fn
+// returns false the value is considered invalid.
+func (b *TextAsBuilder[T]) WithConstraint(
+	desc string,
+	fn func(T) bool,
+) *TextAsBuilder[T] {
+	b.builder.UserConstraint(desc, fn)
+	return b
+}
+
+// WithSensitiveContent marks the variable as containing sensitive content.
+//
+// Values of sensitive variables are not printed to the console or included in
+// generated documentation.
+func (b *TextAsBuilder[T]) WithSensitiveContent() *TextAsBuilder[T] {
+	b.builder.MarkSensitive()
+	return b
+}
+
+// Required completes the build process and registers a required variable with
+// Ferrite's validation system.
+func (b *TextAsBuilder[T]) Required(options ...RequiredOption) Required[T] {
+	return required(b.schema, &b.builder, options...)
+}
+
+// Optional completes the build process and registers an optional variable with
+// Ferrite's validation system.
+func (b *TextAsBuilder[T]) Optional(options ...OptionalOption) Optional[T] {
+	return optional(b.schema, &b.builder, options...)
+}
+
+// Deprecated completes the build process and registers a deprecated variable
+// with Ferrite's validation system.
+func (b *TextAsBuilder[T]) Deprecated(options ...DeprecatedOption) Deprecated[T] {
+	return deprecated(b.schema, &b.builder, options...)
+}
+
+// textMarshaler implements [variable.Marshaler] using closures that invoke the
+// [encoding.TextMarshaler] and [encoding.TextUnmarshaler] interfaces.
+type textMarshaler[T any] struct {
+	marshal   func(T) ([]byte, error)
+	unmarshal func([]byte) (T, error)
+}
+
+func (m textMarshaler[T]) Marshal(v T) (variable.Literal, error) {
+	data, err := m.marshal(v)
+	if err != nil {
+		return variable.Literal{}, err
+	}
+	return variable.Literal{String: string(data)}, nil
+}
+
+func (m textMarshaler[T]) Unmarshal(v variable.Literal) (T, error) {
+	return m.unmarshal([]byte(v.String))
+}

--- a/builder_text_test.go
+++ b/builder_text_test.go
@@ -1,0 +1,284 @@
+package ferrite_test
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/dogmatiq/ferrite"
+	. "github.com/dogmatiq/ferrite"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("type TextAsBuilder", func() {
+	var builder *TextAsBuilder[textValue]
+
+	BeforeEach(func() {
+		builder = TextAs[textValue]("FERRITE_TEXT", "<desc>")
+	})
+
+	AfterEach(func() {
+		tearDown()
+	})
+
+	It("panics if the name is empty", func() {
+		Expect(func() {
+			TextAs[textValue]("", "<desc>").Optional()
+		}).To(PanicWith("invalid specification: variable name must not be empty"))
+	})
+
+	It("panics if the description is empty", func() {
+		Expect(func() {
+			TextAs[textValue]("FERRITE_TEXT", "").Optional()
+		}).To(PanicWith("specification for FERRITE_TEXT is invalid: variable description must not be empty"))
+	})
+
+	When("the variable is required", func() {
+		When("the value is not empty", func() {
+			Describe("func Value()", func() {
+				It("returns the parsed value", func() {
+					os.Setenv("FERRITE_TEXT", "text:hello")
+
+					v := builder.
+						Required().
+						Value()
+
+					Expect(v).To(Equal(textValue{Data: "hello"}))
+				})
+			})
+		})
+
+		When("the value is empty", func() {
+			When("there is a default value", func() {
+				Describe("func Value()", func() {
+					It("returns the default", func() {
+						v := builder.
+							WithDefault(textValue{Data: "fallback"}).
+							Required().
+							Value()
+
+						Expect(v).To(Equal(textValue{Data: "fallback"}))
+					})
+				})
+			})
+
+			When("there is no default value", func() {
+				Describe("func Value()", func() {
+					It("panics", func() {
+						Expect(func() {
+							builder.
+								Required().
+								Value()
+						}).To(PanicWith(
+							"FERRITE_TEXT is undefined and does not have a default value",
+						))
+					})
+				})
+			})
+		})
+	})
+
+	When("the variable is optional", func() {
+		When("the value is not empty", func() {
+			Describe("func Value()", func() {
+				It("returns the parsed value", func() {
+					os.Setenv("FERRITE_TEXT", "text:hello")
+
+					v, ok := builder.
+						Optional().
+						Value()
+
+					Expect(ok).To(BeTrue())
+					Expect(v).To(Equal(textValue{Data: "hello"}))
+				})
+			})
+		})
+
+		When("the value is empty", func() {
+			When("there is a default value", func() {
+				Describe("func Value()", func() {
+					It("returns the default", func() {
+						v, ok := builder.
+							WithDefault(textValue{Data: "fallback"}).
+							Optional().
+							Value()
+
+						Expect(ok).To(BeTrue())
+						Expect(v).To(Equal(textValue{Data: "fallback"}))
+					})
+				})
+			})
+
+			When("there is no default value", func() {
+				Describe("func Value()", func() {
+					It("returns with ok == false", func() {
+						_, ok := builder.
+							Optional().
+							Value()
+
+						Expect(ok).To(BeFalse())
+					})
+				})
+			})
+		})
+	})
+})
+
+var _ = Describe("func TextAsP", func() {
+	var builder *TextAsBuilder[*textValue]
+
+	BeforeEach(func() {
+		builder = TextAsP[textValue]("FERRITE_TEXT_P", "<desc>")
+	})
+
+	AfterEach(func() {
+		tearDown()
+	})
+
+	When("the variable is required", func() {
+		When("the value is not empty", func() {
+			Describe("func Value()", func() {
+				It("returns the parsed value as a pointer", func() {
+					os.Setenv("FERRITE_TEXT_P", "text:hello")
+
+					v := builder.
+						Required().
+						Value()
+
+					Expect(v).To(Equal(&textValue{Data: "hello"}))
+				})
+			})
+		})
+
+		When("the value is empty", func() {
+			When("there is a default value", func() {
+				Describe("func Value()", func() {
+					It("returns the default", func() {
+						v := builder.
+							WithDefault(&textValue{Data: "fallback"}).
+							Required().
+							Value()
+
+						Expect(v).To(Equal(&textValue{Data: "fallback"}))
+					})
+				})
+			})
+		})
+	})
+
+	When("the variable is optional", func() {
+		When("the value is not empty", func() {
+			Describe("func Value()", func() {
+				It("returns the parsed value as a pointer", func() {
+					os.Setenv("FERRITE_TEXT_P", "text:hello")
+
+					v, ok := builder.
+						Optional().
+						Value()
+
+					Expect(ok).To(BeTrue())
+					Expect(v).To(Equal(&textValue{Data: "hello"}))
+				})
+			})
+		})
+
+		When("the value is empty", func() {
+			When("there is no default value", func() {
+				Describe("func Value()", func() {
+					It("returns with ok == false", func() {
+						_, ok := builder.
+							Optional().
+							Value()
+
+						Expect(ok).To(BeFalse())
+					})
+				})
+			})
+		})
+	})
+})
+
+func ExampleTextAs_required() {
+	defer example()()
+
+	v := ferrite.
+		TextAs[textValue]("FERRITE_TEXT", "example text-marshaled variable").
+		Required()
+
+	os.Setenv("FERRITE_TEXT", "text:hello")
+	ferrite.Init()
+
+	fmt.Println("value is", v.Value().Data)
+
+	// Output:
+	// value is hello
+}
+
+func ExampleTextAs_default() {
+	defer example()()
+
+	v := ferrite.
+		TextAs[textValue]("FERRITE_TEXT", "example text-marshaled variable").
+		WithDefault(textValue{Data: "fallback"}).
+		Required()
+
+	ferrite.Init()
+
+	fmt.Println("value is", v.Value().Data)
+
+	// Output:
+	// value is fallback
+}
+
+func ExampleTextAs_optional() {
+	defer example()()
+
+	v := ferrite.
+		TextAs[textValue]("FERRITE_TEXT", "example text-marshaled variable").
+		Optional()
+
+	ferrite.Init()
+
+	if x, ok := v.Value(); ok {
+		fmt.Println("value is", x.Data)
+	} else {
+		fmt.Println("value is undefined")
+	}
+
+	// Output:
+	// value is undefined
+}
+
+func ExampleTextAsP_required() {
+	defer example()()
+
+	v := ferrite.
+		TextAsP[textValue]("FERRITE_TEXT_P", "example text-marshaled pointer variable").
+		Required()
+
+	os.Setenv("FERRITE_TEXT_P", "text:hello")
+	ferrite.Init()
+
+	fmt.Println("value is", v.Value().Data)
+
+	// Output:
+	// value is hello
+}
+
+// textValue is a test type that implements encoding.TextMarshaler and
+// encoding.TextUnmarshaler via its pointer receiver.
+type textValue struct {
+	Data string
+}
+
+func (v textValue) MarshalText() ([]byte, error) {
+	return []byte("text:" + v.Data), nil
+}
+
+func (v *textValue) UnmarshalText(data []byte) error {
+	if len(data) < 5 || string(data[:5]) != "text:" {
+		return fmt.Errorf("expected text: prefix")
+	}
+	v.Data = string(data[5:])
+	return nil
+}

--- a/builder_text_test.go
+++ b/builder_text_test.go
@@ -265,8 +265,8 @@ func ExampleTextAsP_required() {
 	// value is hello
 }
 
-// textValue is a test type that implements encoding.TextMarshaler and
-// encoding.TextUnmarshaler via its pointer receiver.
+// textValue is a test type that implements encoding.TextMarshaler via a value
+// receiver and encoding.TextUnmarshaler via a pointer receiver.
 type textValue struct {
 	Data string
 }

--- a/internal/mode/usage/markdown/spec_text_test.go
+++ b/internal/mode/usage/markdown/spec_text_test.go
@@ -1,0 +1,77 @@
+package markdown_test
+
+import (
+	"fmt"
+
+	"github.com/dogmatiq/ferrite"
+	. "github.com/dogmatiq/ferrite/internal/mode/usage/markdown"
+	. "github.com/onsi/ginkgo/v2"
+)
+
+// textSpecValue is a test type that implements encoding.TextMarshaler and
+// encoding.TextUnmarshaler via its pointer receiver.
+type textSpecValue struct {
+	Data string
+}
+
+func (v textSpecValue) MarshalText() ([]byte, error) {
+	return []byte("text:" + v.Data), nil
+}
+
+func (v *textSpecValue) UnmarshalText(data []byte) error {
+	if len(data) < 5 || string(data[:5]) != "text:" {
+		return fmt.Errorf("expected text: prefix")
+	}
+	v.Data = string(data[5:])
+	return nil
+}
+
+var _ = DescribeTable(
+	"text spec",
+	tableTest(
+		"spec/text",
+		WithoutExplanatoryText(),
+		WithoutIndex(),
+		WithoutUsageExamples(),
+	),
+	Entry(
+		"deprecated",
+		"deprecated.md",
+		func(reg ferrite.Registry) {
+			ferrite.
+				TextAs[textSpecValue]("FERRITE_TEXT", "example text-marshaled value").
+				WithExample(textSpecValue{Data: "hello"}, "a greeting").
+				Deprecated(ferrite.WithRegistry(reg))
+		},
+	),
+	Entry(
+		"optional",
+		"optional.md",
+		func(reg ferrite.Registry) {
+			ferrite.
+				TextAs[textSpecValue]("FERRITE_TEXT", "example text-marshaled value").
+				WithExample(textSpecValue{Data: "hello"}, "a greeting").
+				Optional(ferrite.WithRegistry(reg))
+		},
+	),
+	Entry(
+		"required",
+		"required.md",
+		func(reg ferrite.Registry) {
+			ferrite.
+				TextAs[textSpecValue]("FERRITE_TEXT", "example text-marshaled value").
+				WithExample(textSpecValue{Data: "hello"}, "a greeting").
+				Required(ferrite.WithRegistry(reg))
+		},
+	),
+	Entry(
+		"required with default value",
+		"with-default.md",
+		func(reg ferrite.Registry) {
+			ferrite.
+				TextAs[textSpecValue]("FERRITE_TEXT", "example text-marshaled value").
+				WithDefault(textSpecValue{Data: "fallback"}).
+				Required(ferrite.WithRegistry(reg))
+		},
+	),
+)

--- a/internal/mode/usage/markdown/spec_text_test.go
+++ b/internal/mode/usage/markdown/spec_text_test.go
@@ -8,8 +8,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 )
 
-// textSpecValue is a test type that implements encoding.TextMarshaler and
-// encoding.TextUnmarshaler via its pointer receiver.
+// textSpecValue is a test type that implements encoding.TextMarshaler via a
+// value receiver and encoding.TextUnmarshaler via a pointer receiver.
 type textSpecValue struct {
 	Data string
 }

--- a/internal/mode/usage/markdown/testdata/spec/text/deprecated.md
+++ b/internal/mode/usage/markdown/testdata/spec/text/deprecated.md
@@ -1,0 +1,12 @@
+# Environment Variables
+
+## `FERRITE_TEXT`
+
+> example text-marshaled value
+
+⚠️ The `FERRITE_TEXT` variable is **deprecated**; its use is **NOT RECOMMENDED**
+as it may be removed in a future version.
+
+```bash
+export FERRITE_TEXT=text:hello # a greeting
+```

--- a/internal/mode/usage/markdown/testdata/spec/text/optional.md
+++ b/internal/mode/usage/markdown/testdata/spec/text/optional.md
@@ -1,0 +1,11 @@
+# Environment Variables
+
+## `FERRITE_TEXT`
+
+> example text-marshaled value
+
+The `FERRITE_TEXT` variable **MAY** be left undefined.
+
+```bash
+export FERRITE_TEXT=text:hello # a greeting
+```

--- a/internal/mode/usage/markdown/testdata/spec/text/required.md
+++ b/internal/mode/usage/markdown/testdata/spec/text/required.md
@@ -1,0 +1,11 @@
+# Environment Variables
+
+## `FERRITE_TEXT`
+
+> example text-marshaled value
+
+The `FERRITE_TEXT` variable **MUST NOT** be left undefined.
+
+```bash
+export FERRITE_TEXT=text:hello # a greeting
+```

--- a/internal/mode/usage/markdown/testdata/spec/text/with-default.md
+++ b/internal/mode/usage/markdown/testdata/spec/text/with-default.md
@@ -1,0 +1,12 @@
+# Environment Variables
+
+## `FERRITE_TEXT`
+
+> example text-marshaled value
+
+The `FERRITE_TEXT` variable **MAY** be left undefined, in which case the default
+value of `text:fallback` is used.
+
+```bash
+export FERRITE_TEXT=text:fallback # (default)
+```

--- a/mode_dotenv_test.go
+++ b/mode_dotenv_test.go
@@ -68,6 +68,11 @@ func ExampleInit_exportDotEnvFile() {
 		WithSensitiveContent().
 		Required()
 
+	os.Setenv("FERRITE_TEXT", "text:hello")
+	ferrite.
+		TextAs[textValue]("FERRITE_TEXT", "example text-marshaled").
+		Required()
+
 	os.Setenv("FERRITE_SVC_SERVICE_HOST", "host.example.org")
 	os.Setenv("FERRITE_SVC_SERVICE_PORT", "443")
 	ferrite.
@@ -123,6 +128,9 @@ func ExampleInit_exportDotEnvFile() {
 	//
 	// # kubernetes "ferrite-svc" service port (deprecated)
 	// export FERRITE_SVC_SERVICE_PORT=443
+	//
+	// # example text-marshaled (required)
+	// export FERRITE_TEXT=text:hello
 	//
 	// # example URL (required)
 	// export FERRITE_URL= # https//example.org is invalid: URL must have a scheme

--- a/mode_validate_test.go
+++ b/mode_validate_test.go
@@ -79,6 +79,11 @@ func ExampleInit_validation() {
 		WithSensitiveContent().
 		Required()
 
+	os.Setenv("FERRITE_TEXT", "text:hello")
+	ferrite.
+		TextAs[textValue]("FERRITE_TEXT", "example text").
+		Required()
+
 	os.Setenv("FERRITE_SVC_SERVICE_HOST", "host.example.org")
 	os.Setenv("FERRITE_SVC_SERVICE_PORT", "443")
 	ferrite.
@@ -114,6 +119,7 @@ func ExampleInit_validation() {
 	//    FERRITE_STRING_SENSITIVE  example sensitive string                 <string>           ✓ set to *******
 	//    FERRITE_SVC_SERVICE_HOST  kubernetes "ferrite-svc" service host    <string>           ✓ set to host.example.org
 	//    FERRITE_SVC_SERVICE_PORT  kubernetes "ferrite-svc" service port    <string>           ✓ set to 443
+	//    FERRITE_TEXT              example text                             <string>           ✓ set to text:hello
 	//    FERRITE_URL               example URL                              <string>           ✓ set to https://example.org
 	//  ❯ FERRITE_XTRIGGER          trigger failure for example              <string>           ✗ undefined
 	//
@@ -192,6 +198,11 @@ func ExampleInit_validationWithDefaultValues() {
 		Required()
 
 	ferrite.
+		TextAs[textValue]("FERRITE_TEXT", "example text").
+		WithDefault(textValue{Data: "fallback"}).
+		Required()
+
+	ferrite.
 		KubernetesService("ferrite-svc").
 		WithDefault("host.example.org", "443").
 		Required()
@@ -225,6 +236,7 @@ func ExampleInit_validationWithDefaultValues() {
 	//    FERRITE_STRING_SENSITIVE  example sensitive string               [ <string> ] = *******              ✓ using default value
 	//    FERRITE_SVC_SERVICE_HOST  kubernetes "ferrite-svc" service host  [ <string> ] = host.example.org     ✓ using default value
 	//    FERRITE_SVC_SERVICE_PORT  kubernetes "ferrite-svc" service port  [ <string> ] = 443                  ✓ using default value
+	//    FERRITE_TEXT              example text                           [ <string> ] = text:fallback        ✓ using default value
 	//    FERRITE_URL               example URL                            [ <string> ] = https://example.org  ✓ using default value
 	//  ❯ FERRITE_XTRIGGER          trigger failure for example              <string>                          ✗ undefined
 	//
@@ -290,6 +302,10 @@ func ExampleInit_validationWithOptionalValues() {
 		Optional()
 
 	ferrite.
+		TextAs[textValue]("FERRITE_TEXT", "example text").
+		Optional()
+
+	ferrite.
 		KubernetesService("ferrite-svc").
 		Optional()
 
@@ -321,6 +337,7 @@ func ExampleInit_validationWithOptionalValues() {
 	//    FERRITE_STRING_SENSITIVE  example sensitive string               [ <string> ]         • undefined
 	//    FERRITE_SVC_SERVICE_HOST  kubernetes "ferrite-svc" service host  [ <string> ]         • undefined
 	//    FERRITE_SVC_SERVICE_PORT  kubernetes "ferrite-svc" service port  [ <string> ]         • undefined
+	//    FERRITE_TEXT              example text                           [ <string> ]         • undefined
 	//    FERRITE_URL               example URL                            [ <string> ]         • undefined
 	//  ❯ FERRITE_XTRIGGER          trigger failure for example              <string>           ✗ undefined
 	//
@@ -435,6 +452,11 @@ func ExampleInit_validationWithInvalidValues() {
 		WithSensitiveContent().
 		Required()
 
+	os.Setenv("FERRITE_TEXT", "not-text-prefixed")
+	ferrite.
+		TextAs[textValue]("FERRITE_TEXT", "example text").
+		Required()
+
 	os.Setenv("FERRITE_SVC_SERVICE_HOST", ".local")
 	os.Setenv("FERRITE_SVC_SERVICE_PORT", "https-")
 	ferrite.
@@ -466,6 +488,7 @@ func ExampleInit_validationWithInvalidValues() {
 	//  ❯ FERRITE_STRING_SENSITIVE  example sensitive string                 <string>           ✗ set to *******, must not contain whitespace
 	//  ❯ FERRITE_SVC_SERVICE_HOST  kubernetes "ferrite-svc" service host    <string>           ✗ set to .local, host must not begin or end with a dot
 	//  ❯ FERRITE_SVC_SERVICE_PORT  kubernetes "ferrite-svc" service port    <string>           ✗ set to https-, IANA service name must not begin or end with a hyphen
+	//  ❯ FERRITE_TEXT              example text                             <string>           ✗ set to not-text-prefixed, expected text: prefix
 	//  ❯ FERRITE_URL               example URL                              <string>           ✗ set to /relative/path, URL must have a scheme
 	//
 	// <process exited with error code 1>


### PR DESCRIPTION
Add builders that create environment variables for types implementing `encoding.TextMarshaler` and `encoding.TextUnmarshaler`.

## API

```go
// TextAs creates a builder for types where T itself implements TextMarshaler (value receiver).
// The pointer type parameter P is inferred automatically.
func TextAs[T encoding.TextMarshaler, P interface{ *T; encoding.TextUnmarshaler }](name, desc string, options ...Option) *TextAsBuilder[T]

// TextAsP creates a builder for types where only *T implements both interfaces.
// The pointer type parameter P is inferred automatically.
func TextAsP[T any, P interface{ *T; encoding.TextMarshaler; encoding.TextUnmarshaler }](name, desc string, options ...Option) *TextAsBuilder[P]
```

## Design decisions

- **Separate constructors** rather than a single over-constrained generic: `TextAs` for value-receiver marshaling, `TextAsP` for pointer-only types
- **Inferred pointer type parameter**: callers write `TextAs[MyType]` or `TextAsP[MyType]`, never specifying the second param
- **Uses `variable.TypedOther` schema** (not `TypedString`) since the native type is not a string
- **No round-trip validation**: marshaling back and re-unmarshaling is not enforced
- **Separate from `Custom`**: `TextAs` is a standalone builder, not a wrapper around `Custom`